### PR TITLE
Improve logging and fix error-handler bug

### DIFF
--- a/examples/python/simple_vector_operations.py
+++ b/examples/python/simple_vector_operations.py
@@ -19,11 +19,11 @@ def validate_and_print_results(computed, expected, operation_name):
 def main():
     """
     Run a demonstration of homomorphic vector operations using OpenFHE-NumPy:
-      • addition
-      • subtraction
-      • transpose
-      • elementwise multiplication
-      • inner product via *
+      - addition
+      - subtraction
+      - transpose
+      - elementwise multiplication
+      - inner product via *
     """
     # Cryptographic setup
     mult_depth = 4
@@ -48,7 +48,7 @@ def main():
     # Sample input vectors
     vector_a = [1.0, 2.0, 3.0, 4.0, 5.0]
     vector_b = [4.0, 0.0, 1.0, 3.0, 6.0]
-    vector_c = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
+    vector_c = [1.1, 2.2, 3.3, 4.0, 5.5, 6.6, 7.7, 8.8]
 
     print("\nInput vectors")
     print("vector_a:", vector_a)
@@ -113,7 +113,7 @@ def main():
     onp.gen_transpose_keys(keys.secretKey, ctv_a)
     ctv_a_T = onp.transpose(ctv_a)
     res_T = ctv_a_T.decrypt(keys.secretKey, unpack_type="original")
-    validate_and_print_results(res_T, np.transpose(vector_a), f"Tranpose \n{vector_a}")
+    validate_and_print_results(res_T, np.transpose(vector_a), f"Transpose \n{vector_a}")
 
     # 4) Elementwise multiplication
     ctv_mul = ctv_a * ctv_b
@@ -124,13 +124,13 @@ def main():
         f"Elementwise multiplication \n{vector_a} \n{vector_b} ",
     )
 
-    # 5) Elementwise multiplication
+    # 5) Scalar multiplication
     ctv_mul_scalar = ctv_a * 7
     res_mul_scalar = ctv_mul_scalar.decrypt(keys.secretKey, unpack_type="original")
     validate_and_print_results(
         res_mul_scalar,
         np.multiply(vector_a, 7),
-        f"Scalar Multiplcation \n{vector_a} and 7",
+        f"Scalar Multiplication \n{vector_a} and 7",
     )
 
     # 6) Inner product

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -47,8 +47,8 @@ from .dispatch import register_tensor_function
 
 from openfhe_numpy.tensor.ctarray import CTArray
 from openfhe_numpy.utils.errors import (
-    ONP_ERROR,
-    ONPIncompatibleShape,
+    ONPError,
+    ONPIncompatibleShapeError,
     ONPNotSupportedError,
     ONPValueError,
     ONPDimensionError,
@@ -265,7 +265,8 @@ def _eval_matvec_ct(lhs, rhs):
     cc = rhs.data.GetCryptoContext() if rhs.dtype == "CTArray" else lhs.data.GetCryptoContext()
     if lhs.ndim == 2 and rhs.ndim == 1:
         if lhs.original_shape[1] != rhs.original_shape[0]:
-            ONPIncompatibleShape(
+            raise ONPIncompatibleShapeError(
+                lhs.original_shape, rhs.original_shape,
                 f"Matrix dimension [{lhs.original_shape}] mismatch with vector dimension [{rhs.shape}]"
             )
 
@@ -291,13 +292,13 @@ def _eval_matvec_ct(lhs, rhs):
                 ArrayEncodingType.COL_MAJOR,
             )
         else:
-            ONP_ERROR(
+            raise ONPError(
                 f"Encoding styles of matrix ({lhs.order}) and vector ({rhs.order}) must be complementary (ROW_MAJOR/COL_MAJOR or vice versa)."
             )
     elif lhs.ndim == 1 and rhs.ndim == 1:
         return _dot(lhs, rhs)
     else:
-        ONPIncompatibleShape(lhs.original_shape, rhs.original_shape, "Matrix Product")
+        raise ONPIncompatibleShapeError(lhs.original_shape, rhs.original_shape, "Matrix Product")
 
 
 def _matmul_ct(lhs, rhs):
@@ -372,10 +373,10 @@ def transpose_ct(a):
 def _pow(x, exp: int):
     """Exponentiate a matrix to power k using homomorphic multiplication."""
     if not isinstance(exp, int):
-        ONP_ERROR(f"Exponent must be integer, got {type(exp).__name__}")
+        raise ONPError(f"Exponent must be integer, got {type(exp).__name__}")
 
     if exp < 0:
-        ONP_ERROR("Negative exponent not supported in homomorphic encryption")
+        raise ONPError("Negative exponent not supported in homomorphic encryption")
 
     if exp == 0:
         # return algebra.eye(tensor))
@@ -453,7 +454,7 @@ def _reduce_ct(a, axis=0, keepdims=False):
         A new tensor with cumulative reduction along the specified axis.
     """
     if axis not in (0, 1):
-        ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+        raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
     if axis == 0:
         ciphertext = EvalReduceCumRows(a.data, a.ncols, a.original_shape[1])
@@ -543,7 +544,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             order = ArrayEncodingType.ROW_MAJOR
 
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}] ")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}] ")
 
         if keepdims:
             shape = (cols, 1)
@@ -561,7 +562,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             padded_shape = (ncols, nrows)
             order = ArrayEncodingType.COL_MAJOR
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}]")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}]")
 
         if keepdims:
             shape = (rows, 1)
@@ -569,7 +570,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             shape = (rows,)
 
     else:
-        ONPValueError(f"Invalid axis [{axis}]")
+        raise ONPValueError(f"Invalid axis [{axis}]")
 
     return CTArray(ct_sum, shape, x.batch_size, padded_shape, order)
 
@@ -580,7 +581,7 @@ def _ct_sum_vector(
 ):
     crypto_context = x.data.GetCryptoContext()
     if axis is not None:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
     ct_sum = crypto_context.EvalSum(x.data, x.shape[0])
     return CTArray(ct_sum, (), x.batch_size, x.shape, x.order)
 
@@ -592,7 +593,7 @@ def sum_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif x.ndim == 1:
         return _ct_sum_vector(x, axis)
     else:
-        ONPDimensionError(f"The dimension is invalid = {x.ndims}")
+        raise ONPDimensionError(f"The dimension is invalid = {x.ndims}")
 
 
 # ------------------------------------------------------------------------------
@@ -612,7 +613,7 @@ def mean_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif axis == 1:  # sum over cols
         ct_mean = cc.EvalMult(sum_x.data, 1.0 / ncols)
     else:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
 
     return CTArray(
         ct_mean,
@@ -633,7 +634,7 @@ def roll(x: ArrayLike, shift: int, axis: Optional[int] = None) -> ArrayLike:
     if axis is None:
         return _ct_vector_rotation(x, -shift)
     else:
-        ONP_ERROR(f"This function only supports packed vector")
+        raise ONPError(f"This function only supports packed vector")
 
 
 def _ct_vector_rotation(ctv: CTArray, shift: int):

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -30,7 +30,7 @@
 # ==================================================================================
 
 """
-Array constructor functions for OpenFHE-NumPy.
+Constructor functions for OpenFHE-NumPy.
 
 This module provides functions to create FHE array from various input types,
 including support for block-based tensor operations.
@@ -43,7 +43,7 @@ from openfhe import CryptoContext, PublicKey
 
 # Package-level imports
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.matlib import is_power_of_two
 from openfhe_numpy.utils.packing import (
     _pack_matrix_col_wise,
@@ -136,11 +136,11 @@ def _pack_array(
       - order          : int
     """
     if batch_size < 0:
-        ONP_ERROR("The batch size cannot be negative.")
+        raise ONPError("The batch size cannot be negative.")
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two.")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two.")
 
-    data = np.array(data)
+    data = np.asarray(data)
 
     if is_numeric_scalar(data):
         if mode == "zero":
@@ -149,7 +149,7 @@ def _pack_array(
         elif mode == "tile":
             packed = np.full(batch_size, data)
         else:
-            ONP_ERROR(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
+            raise ONPError(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
         shape = (batch_size, 1)
 
     elif is_numeric_arraylike(data):
@@ -158,10 +158,10 @@ def _pack_array(
         elif data.ndim == 1:
             packed, shape = _ravel_vector(data, batch_size, order, True, mode, **kwargs)
         else:
-            ONP_ERROR(f"Unsupported data dimension [{data.ndim}].")
+            raise ONPError(f"Unsupported data dimension [{data.ndim}].")
 
     else:
-        ONP_ERROR("Input is not numeric.")
+        raise ONPError("Input is not numeric.")
 
     return PackedArrayInformation(
         data=packed,
@@ -202,12 +202,12 @@ def array(
     FHETensor
     """
     if cc is None:
-        ONP_ERROR("CryptoContext does not exist")
+        raise ONPError("CryptoContext does not exist")
 
     if batch_size is None:
         batch_size = cc.GetBatchSize()
     if not isinstance(batch_size, int) or batch_size < 0:
-        ONP_ERROR(f"batch_size must be a non-negative int or None, got {batch_size}.")
+        raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
     if not package:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
@@ -215,7 +215,7 @@ def array(
     try:
         plaintext = cc.MakeCKKSPackedPlaintext(package.data)
     except Exception as e:
-        ONP_ERROR("Error: " + str(e))
+        raise ONPError("Error: " + str(e))
 
     if fhe_type == "P":
         return PTArray(
@@ -227,7 +227,7 @@ def array(
         )
     elif fhe_type == "C":
         if public_key is None:
-            ONP_ERROR("Public key must be provided for ciphertext encoding.")
+            raise ONPError("Public key must be provided for ciphertext encoding.")
         try:
             ciphertext = cc.Encrypt(public_key, plaintext)
             return CTArray(
@@ -238,9 +238,9 @@ def array(
                 package.order,  # order
             )
         except Exception as e:
-            ONP_ERROR(f"Failed to encrypt: {e}")
+            raise ONPError(f"Failed to encrypt: {e}")
     else:
-        ONP_ERROR(f"type must be 'C' or 'P', got '{fhe_type}'.")
+        raise ONPError(f"type must be 'C' or 'P', got '{fhe_type}'.")
 
 
 def _ravel_matrix(
@@ -315,7 +315,7 @@ def _ravel_vector(
     """
     target_cols = kwargs.get("target_cols")
     if target_cols is not None and not (isinstance(target_cols, int) and target_cols > 0):
-        ONP_ERROR(f"target_cols must be positive int or None, got {target_cols!r}.")
+        raise ONPError(f"target_cols must be positive int or None, got {target_cols!r}.")
 
     pad_value = kwargs.get("pad_value", "tile")
     expand = kwargs.get("expand", "tile")
@@ -341,4 +341,4 @@ def _ravel_vector(
             pad_value=pad_value,
         )
     else:
-        ONP_ERROR("Unsupported encoding order")
+        raise ONPError("Unsupported encoding order")

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -38,7 +38,7 @@ import openfhe
 from ..openfhe_numpy import EvalSumCumCols, EvalSumCumRows, EvalTranspose, ArrayEncodingType
 from ..utils.matlib import next_power_of_two
 from ..utils.constants import UnpackType
-from ..utils.errors import ONP_ERROR
+from ..utils.errors import ONPError
 from ..utils.packing import process_packed_data
 from ..utils._helper_slots_ops import _get_single_element
 
@@ -243,12 +243,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             The decrypted data, formatted by 'unpack_type'.
         """
         if secret_key is None:
-            ONP_ERROR("Secret key is missing.")
+            raise ONPError("Secret key is missing.")
 
         cc = self.data.GetCryptoContext()
         plaintext = cc.Decrypt(self.data, secret_key)
         if plaintext is None:
-            ONP_ERROR("Decryption failed.")
+            raise ONPError("Decryption failed.")
 
         plaintext.SetLength(self.batch_size)
         result = plaintext.GetRealPackedValue()
@@ -269,7 +269,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
         stream = io.BytesIO()
         if not openfhe.Serialize(self.data, stream):
-            ONP_ERROR("Failed to serialize ciphertext.")
+            raise ONPError("Failed to serialize ciphertext.")
 
         return {
             "type": self.type,
@@ -294,12 +294,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         ]
         for key in required_keys:
             if key not in obj:
-                ONP_ERROR(f"Missing required key '{key}' in serialized object.")
+                raise ONPError(f"Missing required key '{key}' in serialized object.")
 
         stream = io.BytesIO(bytes.fromhex(obj["ciphertext"]))
         ciphertext = openfhe.Ciphertext()
         if not openfhe.Deserialize(ciphertext, stream):
-            ONP_ERROR("Failed to deserialize ciphertext.")
+            raise ONPError("Failed to deserialize ciphertext.")
 
         return cls(
             ciphertext,
@@ -353,13 +353,13 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
 
         if self.ndim != 1 and self.ndim != 2:
-            ONP_ERROR(f"Dimension of array {self.ndim} is illegal ")
+            raise ONPError(f"Dimension of array {self.ndim} is illegal ")
 
         if self.ndim != 1 and axis is None:
-            ONP_ERROR("axis=None not allowed for >1D")
+            raise ONPError("axis=None not allowed for >1D")
 
         if self.ndim == 2 and axis not in (0, 1):
-            ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+            raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
         order = self.order
         shape = self.shape
@@ -377,7 +377,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumCols(self.data, self.nrows)
 
             else:
-                raise ONP_ERROR(f"Not support this packing order [{self.order}].")
+                raise ONPError(f"Not support this packing order [{self.order}].")
 
         # cumulative_sum over cols
         elif axis == 1:
@@ -388,9 +388,9 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumRows(self.data, self.nrows, self.original_shape[0])
 
             else:
-                raise ONP_ERROR(f"Not support this packing order[{self.order}].")
+                raise ONPError(f"Not support this packing order[{self.order}].")
         else:
-            raise ONP_ERROR(f"Invalid axis [{axis}].")
+            raise ONPError(f"Invalid axis [{axis}].")
         return CTArray(ciphertext, original_shape, self.batch_size, shape, order)
 
     def gen_sum_row_key(self, secret_key: openfhe.PrivateKey) -> openfhe.EvalKey:

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -37,7 +37,7 @@ from typing import overload, Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 import numpy as np
 
 # Internal C++ module Imports
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.constants import *
 
 # -----------------------------------------------------------
@@ -162,7 +162,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             self.extra = {}
         else:
             if None in (original_shape, batch_size, new_shape):
-                ONP_ERROR(
+                raise ONPError(
                     "Raw form requires (data, original_shape, ndim, batch_size, shape[, order])"
                 )
             self._data = data
@@ -172,7 +172,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
 
             self._ndim = len(original_shape)
             if self._ndim > 2 or self._ndim < 0:
-                ONP_ERROR("Dimension is invalid!!!")
+                raise ONPError("Dimension is invalid!!!")
             self._order = order
             self._dtype = self.__class__.__name__
             self._zeros = None
@@ -209,7 +209,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         elif isinstance(data, openfhe.Plaintext):
             self._dtype = "PTArray"
         else:
-            ONP_ERROR(
+            raise ONPError(
                 "Object data is incorrect. \
                       Only support FHETensor only supports Ciphertext or Plaintext"
             )
@@ -274,7 +274,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         if order in ["R", "C"]:
             self._order = order
         else:
-            ONP_ERROR("Not support order [{order}]")
+            raise ONPError(f"Not support order [f{order}]")
 
     @property
     def is_encrypted(self) -> int:
@@ -296,6 +296,17 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     @property
     def T(self):
         return self.transpose()
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"original_shape={self.original_shape}, "
+            f"batch_size={self.batch_size}, "
+            f"shape={self.shape}, "
+            f"order={self.order}, "
+            f"ndim={self.ndim}, "
+            f"extra={self.extra})"
+        )
 
     ###
     ### Update properties in some specific cases

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -28,252 +28,288 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
-
 """Logging and error handling for OpenFHE-NumPy.
 
 This module provides:
-1. A configured logger with consistent log formatting
-2. Custom exceptions with stack trace information
-3. Convenience functions for logging at different levels
-4. Configuration management via environment variables
+1. A package-level logger for OpenFHE-NumPy.
+2. Custom exception classes for user-facing tensor errors.
+3. Convenience logging helpers.
+4. Optional logging configuration through environment variables.
 
-Environment Variables:
-    OPENFHE_DEBUG: Enable debug logging ("ON", "1", "TRUE")
-    OPENFHE_LOG_FORMAT: Custom log format string
-    OPENFHE_LOG_FILE: Path to log file (optional)
-    OPENFHE_LOG_MAX_SIZE: Maximum log file size in bytes
-    OPENFHE_LOG_BACKUP_COUNT: Number of backup log files
+Logging policy
+--------------
+Default behavior:
+    No logs are printed by OpenFHE-NumPy.
 
-Usage::
-    from openfhe_numpy.utils.errors import ONP_DEBUG, ONP_ERROR, ONP_WARNING
+If the user sets OPENFHE_DEBUG or OPENFHE_LOG_FILE:
+    OpenFHE-NumPy configures its own logging.
 
-    ONP_DEBUG("Processing data...")
-    ONP_WARNING("Unusual input detected")
-    if problem:
-        ONP_ERROR("Invalid input data")
+If the application configures logging itself:
+    OpenFHE-NumPy respects that configuration.
+
+Environment variables
+---------------------
+OPENFHE_DEBUG:
+    Enable debug logging when set to "ON", "1", "TRUE", or "YES".
+
+OPENFHE_LOG_FORMAT:
+    Custom logging format string.
+
+OPENFHE_LOG_FILE:
+    Optional path to a log file.
+
+OPENFHE_LOG_MAX_SIZE:
+    Maximum rotating log file size in bytes. Default: 10MB.
+
+OPENFHE_LOG_BACKUP_COUNT:
+    Number of rotated backup log files. Default: 5.
+
+Backward compatibility
+----------------------
+FP_ENABLE_DEBUG:
+    Also enables debug logging when set to "ON", "1", "TRUE", or "YES".
 """
 
-import inspect
-import os
+from __future__ import annotations
+
 import logging
-import threading
-import traceback
-from typing import Any, Dict
+import os
+import warnings
 from logging.handlers import RotatingFileHandler
-
-# === Configuration ===
-
-# Default configuration values
-DEFAULT_CONFIG = {
-    "enable_debug": False,
-    "log_format": "%(asctime)s - %(levelname)s - %(message)s",
-    "log_file": None,
-    "max_file_size": 10 * 1024 * 1024,  # 10MB
-    "backup_count": 5,
-}
+from typing import Optional
 
 
-def get_config() -> Dict[str, Any]:
-    """Get logging configuration from environment variables with defaults."""
-    return {
-        "enable_debug": os.getenv("OPENFHE_DEBUG", "OFF").upper() in ("ON", "1", "TRUE"),
-        "log_format": os.getenv("OPENFHE_LOG_FORMAT", DEFAULT_CONFIG["log_format"]),
-        "log_file": os.getenv("OPENFHE_LOG_FILE", DEFAULT_CONFIG["log_file"]),
-        "max_file_size": int(
-            os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_CONFIG["max_file_size"]))
-        ),
-        "backup_count": int(
-            os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_CONFIG["backup_count"]))
-        ),
-    }
+# =============================================================================
+# Logging configuration
+# =============================================================================
+
+LOGGER_NAME = "openfhe_numpy"
+
+_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_BACKUP_COUNT = 5
 
 
-# Load configuration (done once at module import time)
-_config = get_config()
+def _env_flag_enabled(name: str, default: str = "OFF") -> bool:
+    """Return True if an environment flag is enabled."""
+    return os.getenv(name, default).upper() in {"ON", "1", "TRUE", "YES"}
 
-# For backward compatibility
-ENABLE_DEBUG = _config["enable_debug"]
-if os.getenv("FP_ENABLE_DEBUG", "OFF").upper() == "ON":
-    ENABLE_DEBUG = True
-    _config["enable_debug"] = True
 
-_logger = None
-_logger_lock = threading.Lock()
+def debug_enabled() -> bool:
+    """Return whether OpenFHE-NumPy debug logging is enabled."""
+    return _env_flag_enabled("OPENFHE_DEBUG") or _env_flag_enabled("FP_ENABLE_DEBUG")
+
+
+def _explicit_logging_requested() -> bool:
+    """Return True if OpenFHE-NumPy should configure its own logging."""
+    return (
+        debug_enabled()
+        or os.getenv("OPENFHE_LOG_FILE") is not None
+        or os.getenv("OPENFHE_LOG_FORMAT") is not None
+    )
 
 
 def get_logger() -> logging.Logger:
-    """Thread-safe singleton logger with console + optional rotating file output."""
-    global _logger
-    if _logger is None:
-        with _logger_lock:
-            if _logger is None:
-                _logger = logging.getLogger("openfhe_numpy")
+    """Return the OpenFHE-NumPy package logger.
 
-                if not _logger.handlers:
-                    formatter = logging.Formatter(_config["log_format"])
+    By default, the logger is silent and uses ``NullHandler``. This is the
+    recommended behavior for open-source libraries: importing the package should
+    not unexpectedly print logs.
 
-                    # Rotating file handler (optional)
-                    log_file = _config["log_file"]
-                    if log_file:
-                        try:
-                            file_handler = RotatingFileHandler(
-                                log_file,
-                                maxBytes=_config["max_file_size"],
-                                backupCount=_config["backup_count"],
-                            )
-                            file_handler.setFormatter(formatter)
-                            _logger.addHandler(file_handler)
-                        except Exception as e:
-                            print(f"Warning: Could not set up file logging: {e}")
+    If ``OPENFHE_DEBUG``, ``FP_ENABLE_DEBUG``, ``OPENFHE_LOG_FILE``, or
+    ``OPENFHE_LOG_FORMAT`` is set, OpenFHE-NumPy configures its own handler.
 
-                    # Console handler
-                    stream_handler = logging.StreamHandler()
-                    stream_handler.setFormatter(formatter)
-                    stream_handler.setLevel(
-                        logging.DEBUG if _config["enable_debug"] else logging.INFO
-                    )
-                    _logger.addHandler(stream_handler)
+    If an application has already configured the ``openfhe_numpy`` logger, this
+    function leaves that configuration unchanged.
+    """
+    logger = logging.getLogger(LOGGER_NAME)
 
-                    _logger.setLevel(logging.DEBUG)
-                    _logger.propagate = False
-    return _logger
+    # Respect application/test configuration.
+    if logger.handlers:
+        return logger
+
+    if not _explicit_logging_requested():
+        logger.addHandler(logging.NullHandler())
+        logger.propagate = True
+        return logger
+
+    handler_level = logging.DEBUG if debug_enabled() else logging.INFO
+    log_format = os.getenv("OPENFHE_LOG_FORMAT", _LOG_FORMAT)
+    formatter = logging.Formatter(log_format)
+
+    # Console handler is enabled only when logging is explicitly requested.
+    if debug_enabled() or os.getenv("OPENFHE_LOG_FORMAT") is not None:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(handler_level)
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
+
+    # Optional rotating file handler.
+    log_file = os.getenv("OPENFHE_LOG_FILE")
+    if log_file:
+        try:
+            max_file_size = int(os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_MAX_FILE_SIZE)))
+            backup_count = int(os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_BACKUP_COUNT)))
+
+            file_handler = RotatingFileHandler(
+                log_file,
+                maxBytes=max_file_size,
+                backupCount=backup_count,
+            )
+            file_handler.setLevel(handler_level)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+        except Exception as exc:
+            warnings.warn(
+                f"Could not set up OpenFHE-NumPy file logging: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    # Keep logger permissive; handlers decide what to emit.
+    logger.setLevel(logging.DEBUG)
+
+    # Avoid duplicate messages through the root logger once we add handlers.
+    logger.propagate = False
+
+    return logger
 
 
-# === Custom Exceptions ===
+logger = get_logger()
+
+
+# =============================================================================
+# Custom exceptions
+# =============================================================================
 
 
 class ONPError(Exception):
-    """Base class for OpenFHE-NumPy errors."""
-
-    def __init__(self, message: str):
-        stack = traceback.extract_stack(limit=2)[-2]
-        filename = os.path.basename(stack.filename)
-        function_name = stack.name
-        line_number = stack.lineno
-        full_message = f'{message}\n    File: "{filename}", line {line_number}, in {function_name}'
-        super().__init__(full_message)
+    """Base class for all OpenFHE-NumPy errors."""
 
 
 class ONPTypeError(ONPError, TypeError):
-    """Raised when incorrect types are provided."""
-
-    pass
+    """Raised when an object has an invalid type."""
 
 
 class ONPDimensionError(ONPError, ValueError):
-    """Raised when an invalid axis is provided."""
-
-    pass
+    """Raised when a tensor dimension, rank, or axis is invalid."""
 
 
 class ONPValueError(ONPError, ValueError):
     """Raised when an invalid value is encountered."""
 
-    def __init__(self, message: str = "Invalid value encountered."):
+    def __init__(self, message: str = "Invalid value encountered.") -> None:
         super().__init__(message)
 
 
-class ONPIncompatibleShape(ONPValueError, ValueError):
-    """Raised when tensor shapes are incompatible."""
+class ONPIncompatibleShapeError(ONPError, ValueError):
+    """Raised when tensor shapes are incompatible for an operation."""
 
-    def __init__(self, shape_a, shape_b, message: str = None):
+    def __init__(
+        self,
+        shape_a: object,
+        shape_b: object,
+        message: Optional[str] = None,
+    ) -> None:
         if message is None:
             message = f"Incompatible shapes: {shape_a} vs {shape_b}"
         super().__init__(message)
 
 
 class ONPNotImplementedError(ONPError, NotImplementedError):
-    """Raised when a feature is not implemented."""
+    """Raised when a feature is not yet implemented."""
 
-    def __init__(self, message: str = "This feature is not implemented."):
-        super().__init__(f"{message}")
+    def __init__(self, message: str = "This feature is not implemented.") -> None:
+        super().__init__(message)
 
 
 class ONPNotSupportedError(ONPError, NotImplementedError):
-    """Raised when a feature is not supported."""
+    """Raised when a feature is intentionally not supported."""
 
-    def __init__(self, message: str = "This feature is not supported."):
-        super().__init__(f"{message}")
-
-
-# === Logging Helpers ===
+    def __init__(self, message: str = "This feature is not supported.") -> None:
+        super().__init__(message)
 
 
-def _format_log(level: str, message: str, stack_level: int = 2) -> str:
-    frame = inspect.stack()[stack_level]
-    filename = os.path.basename(frame.filename)
-    function_name = frame.function
-    line_number = frame.lineno
-    return f'[{level}] {message}\n    File: "{filename}", line {line_number}, in {function_name}'
-
-
-def _log(level: str, message: str, stack_level: int = 2) -> None:
-    formatted_message = _format_log(level, message, stack_level)
-    logger = get_logger()
-    if level == "ONP_ERROR":
-        logger.error(formatted_message)
-    elif level == "ONP_DEBUG" and ENABLE_DEBUG:
-        logger.debug(formatted_message)
-    elif level == "ONP_WARNING":
-        logger.warning(formatted_message)
-    elif level == "ONP_INFO":
-        logger.info(formatted_message)
-    else:
-        return
-
-
-# === Public API ===
+# =============================================================================
+# Logging helpers
+# =============================================================================
 
 
 def ONP_INFO(message: str) -> None:
-    _log("ONP_INFO", message)
-
-
-def ONP_ERROR(message: str, raise_exception: bool = True) -> None:
-    _log("ONP_ERROR", message)
-    if raise_exception:
-        raise ONPError(message)
+    """Log an informational message."""
+    logger.info(message, stacklevel=2)
 
 
 def ONP_DEBUG(message: str) -> None:
-    _log("ONP_DEBUG", message)
+    """Log a debug message.
+
+    Visibility is controlled by logger and handler levels.
+    """
+    logger.debug(message, stacklevel=2)
 
 
 def ONP_WARNING(message: str) -> None:
-    _log("ONP_WARNING", message)
+    """Log a warning message."""
+    logger.warning(message, stacklevel=2)
+
+
+def ONP_ERROR(message: str) -> None:
+    """Log an error message."""
+    logger.error(message, stacklevel=2)
+
+
+# =============================================================================
+# Testing helper
+# =============================================================================
 
 
 def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
-    """Capture logs for testing.
-
-    Returns a handler that collects logs for inspection in tests.
+    """Attach an in-memory log handler for tests.
 
     Parameters
     ----------
-    level : int, optional
-        Logging level to capture (default: logging.DEBUG)
+    level:
+        Logging level to capture.
 
     Returns
     -------
     logging.Handler
-        A handler with a 'messages' attribute containing captured log messages
+        A handler with a ``messages`` attribute containing formatted log records.
 
     Example
     -------
-    handler = capture_logs()
-    ONP_DEBUG("Test message")
-    assert "Test message" in handler.messages
+    >>> handler = capture_logs()
+    >>> ONP_DEBUG("test message")
+    >>> assert any("test message" in msg for msg in handler.messages)
     """
 
     class MemoryHandler(logging.Handler):
+        """Simple in-memory logging handler."""
+
         def __init__(self) -> None:
             super().__init__(level)
-            self.messages = []
+            self.messages: list[str] = []
 
         def emit(self, record: logging.LogRecord) -> None:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
+    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
-    get_logger().addHandler(handler)
+
+    test_logger = get_logger()
+
+    # Remove the default no-op handler in tests, if present.
+    test_logger.handlers = [
+        existing_handler
+        for existing_handler in test_logger.handlers
+        if not isinstance(existing_handler, logging.NullHandler)
+    ]
+
+    test_logger.addHandler(handler)
+
+    # Make sure debug messages can reach the test handler.
+    test_logger.setLevel(logging.DEBUG)
+
     return handler

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -295,17 +295,13 @@ def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
-    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
 
     test_logger = get_logger()
 
-    # Remove the default no-op handler in tests, if present.
-    test_logger.handlers = [
-        existing_handler
-        for existing_handler in test_logger.handlers
-        if not isinstance(existing_handler, logging.NullHandler)
-    ]
+    for existing_handler in list(test_logger.handlers):
+        if isinstance(existing_handler, logging.NullHandler):
+            test_logger.removeHandler(existing_handler)
 
     test_logger.addHandler(handler)
 

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -51,7 +51,7 @@ from numpy.typing import ArrayLike
 
 from openfhe_numpy.openfhe_numpy import *
 
-from .errors import ONP_ERROR
+from .errors import ONPError
 from .matlib import is_power_of_two, next_power_of_two
 from .typecheck import *
 
@@ -99,7 +99,7 @@ def _pack_vector_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If expand mode is invalid
@@ -117,7 +117,7 @@ def _pack_vector_row_wise(
     """
 
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -130,7 +130,7 @@ def _pack_vector_row_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     flattened = np.zeros(expanded_size, dtype=np.asarray(vector).dtype)
     if expand == "tile":
@@ -141,21 +141,21 @@ def _pack_vector_row_wise(
             for i in range(n):
                 flattened[i * ncols : (i + 1) * ncols] = vector[i]
         else:
-            ONP_ERROR(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
+            raise ONPError(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
     elif expand == "zero":
         flattened[np.arange(n) * target_cols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size < (expanded_size * tiles):
-        ONP_ERROR(
+        raise ONPError(
             f"Padded vector [{expanded_size} x {tiles}] is longer than the batch size [{batch_size}]"
         )
 
@@ -201,7 +201,7 @@ def _pack_vector_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If tile_mode is invalid
@@ -217,7 +217,7 @@ def _pack_vector_col_wise(
 
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -229,7 +229,7 @@ def _pack_vector_col_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     padded = np.zeros(nrows, dtype=vector.dtype)
     padded[:n] = vector
@@ -244,14 +244,14 @@ def _pack_vector_col_wise(
     elif expand == "zero":
         flattened[: n * ncols : ncols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     total_len = tiles * expanded_size
     output = np.zeros(batch_size, dtype=flattened.dtype)
@@ -300,12 +300,12 @@ def _pack_matrix_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If 'batch_size' is not a power of two, not divisible by the padded size,
         or insufficient to hold the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -325,13 +325,13 @@ def _pack_matrix_row_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -383,12 +383,12 @@ def _pack_matrix_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If batch_size is not a power of two, or if batch_size is not divisible by
         the required size, or if batch_size is insufficient for the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -408,13 +408,13 @@ def _pack_matrix_col_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -543,7 +543,7 @@ def _extract_matrix(data, info):
         tranposed = np.transpose(reshaped)
         return tranposed[: info["original_shape"][0], : info["original_shape"][1]]
     else:
-        ONP_ERROR("Order is not supported!!!")
+        raise ONPError("Order is not supported!!!")
         return None
 
 
@@ -572,8 +572,7 @@ def _extract_vector(data, info):
         elif info["order"] == COL_MAJOR:
             return reshaped[0, :original_row]
         else:
-            ONP_ERROR("Order is not supported!!!")
-            return None
+            raise ONPError("Order is not supported!!!")
     else:
         return data[0]
 


### PR DESCRIPTION
Related to #65 
This PR cleans up error handling and logging usage across OpenFHE-NumPy.

## Changes

* Replaced incorrect `ONP_ERROR()` usage with direct `raise ONPError(...)` where an exception should be raised instead of only logged.
* Fixed places where custom exception objects were constructed but never raised, including:

  * `ONPIncompatibleShape`
  * `ONPDimensionError`
  * `ONPNotSupportedError`
  * `ONPValueError`
* Updated imports:

  * `ONP_ERROR` → `ONPError`
* Removed the old `ONPIncompatibleShape` alias to  `ONPIncompatibleShapeError`.
* Added minor cosmetic cleanup for consistency and readability.
