### PR TITLE
Add constructor for block tensor

### DIFF
--- a/examples/python/simple_vector_operations.py
+++ b/examples/python/simple_vector_operations.py
@@ -19,11 +19,11 @@ def validate_and_print_results(computed, expected, operation_name):
 def main():
     """
     Run a demonstration of homomorphic vector operations using OpenFHE-NumPy:
-      • addition
-      • subtraction
-      • transpose
-      • elementwise multiplication
-      • inner product via *
+      - addition
+      - subtraction
+      - transpose
+      - elementwise multiplication
+      - inner product via *
     """
     # Cryptographic setup
     mult_depth = 4
@@ -48,7 +48,7 @@ def main():
     # Sample input vectors
     vector_a = [1.0, 2.0, 3.0, 4.0, 5.0]
     vector_b = [4.0, 0.0, 1.0, 3.0, 6.0]
-    vector_c = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
+    vector_c = [1.1, 2.2, 3.3, 4.0, 5.5, 6.6, 7.7, 8.8]
 
     print("\nInput vectors")
     print("vector_a:", vector_a)
@@ -113,7 +113,7 @@ def main():
     onp.gen_transpose_keys(keys.secretKey, ctv_a)
     ctv_a_T = onp.transpose(ctv_a)
     res_T = ctv_a_T.decrypt(keys.secretKey, unpack_type="original")
-    validate_and_print_results(res_T, np.transpose(vector_a), f"Tranpose \n{vector_a}")
+    validate_and_print_results(res_T, np.transpose(vector_a), f"Transpose \n{vector_a}")
 
     # 4) Elementwise multiplication
     ctv_mul = ctv_a * ctv_b
@@ -124,13 +124,13 @@ def main():
         f"Elementwise multiplication \n{vector_a} \n{vector_b} ",
     )
 
-    # 5) Elementwise multiplication
+    # 5) Scalar multiplication
     ctv_mul_scalar = ctv_a * 7
     res_mul_scalar = ctv_mul_scalar.decrypt(keys.secretKey, unpack_type="original")
     validate_and_print_results(
         res_mul_scalar,
         np.multiply(vector_a, 7),
-        f"Scalar Multiplcation \n{vector_a} and 7",
+        f"Scalar Multiplication \n{vector_a} and 7",
     )
 
     # 6) Inner product

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -47,8 +47,8 @@ from .dispatch import register_tensor_function
 
 from openfhe_numpy.tensor.ctarray import CTArray
 from openfhe_numpy.utils.errors import (
-    ONP_ERROR,
-    ONPIncompatibleShape,
+    ONPError,
+    ONPIncompatibleShapeError,
     ONPNotSupportedError,
     ONPValueError,
     ONPDimensionError,
@@ -265,7 +265,8 @@ def _eval_matvec_ct(lhs, rhs):
     cc = rhs.data.GetCryptoContext() if rhs.dtype == "CTArray" else lhs.data.GetCryptoContext()
     if lhs.ndim == 2 and rhs.ndim == 1:
         if lhs.original_shape[1] != rhs.original_shape[0]:
-            ONPIncompatibleShape(
+            raise ONPIncompatibleShapeError(
+                lhs.original_shape, rhs.original_shape,
                 f"Matrix dimension [{lhs.original_shape}] mismatch with vector dimension [{rhs.shape}]"
             )
 
@@ -291,13 +292,13 @@ def _eval_matvec_ct(lhs, rhs):
                 ArrayEncodingType.COL_MAJOR,
             )
         else:
-            ONP_ERROR(
+            raise ONPError(
                 f"Encoding styles of matrix ({lhs.order}) and vector ({rhs.order}) must be complementary (ROW_MAJOR/COL_MAJOR or vice versa)."
             )
     elif lhs.ndim == 1 and rhs.ndim == 1:
         return _dot(lhs, rhs)
     else:
-        ONPIncompatibleShape(lhs.original_shape, rhs.original_shape, "Matrix Product")
+        raise ONPIncompatibleShapeError(lhs.original_shape, rhs.original_shape, "Matrix Product")
 
 
 def _matmul_ct(lhs, rhs):
@@ -372,10 +373,10 @@ def transpose_ct(a):
 def _pow(x, exp: int):
     """Exponentiate a matrix to power k using homomorphic multiplication."""
     if not isinstance(exp, int):
-        ONP_ERROR(f"Exponent must be integer, got {type(exp).__name__}")
+        raise ONPError(f"Exponent must be integer, got {type(exp).__name__}")
 
     if exp < 0:
-        ONP_ERROR("Negative exponent not supported in homomorphic encryption")
+        raise ONPError("Negative exponent not supported in homomorphic encryption")
 
     if exp == 0:
         # return algebra.eye(tensor))
@@ -453,7 +454,7 @@ def _reduce_ct(a, axis=0, keepdims=False):
         A new tensor with cumulative reduction along the specified axis.
     """
     if axis not in (0, 1):
-        ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+        raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
     if axis == 0:
         ciphertext = EvalReduceCumRows(a.data, a.ncols, a.original_shape[1])
@@ -543,7 +544,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             order = ArrayEncodingType.ROW_MAJOR
 
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}] ")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}] ")
 
         if keepdims:
             shape = (cols, 1)
@@ -561,7 +562,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             padded_shape = (ncols, nrows)
             order = ArrayEncodingType.COL_MAJOR
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}]")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}]")
 
         if keepdims:
             shape = (rows, 1)
@@ -569,7 +570,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             shape = (rows,)
 
     else:
-        ONPValueError(f"Invalid axis [{axis}]")
+        raise ONPValueError(f"Invalid axis [{axis}]")
 
     return CTArray(ct_sum, shape, x.batch_size, padded_shape, order)
 
@@ -580,7 +581,7 @@ def _ct_sum_vector(
 ):
     crypto_context = x.data.GetCryptoContext()
     if axis is not None:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
     ct_sum = crypto_context.EvalSum(x.data, x.shape[0])
     return CTArray(ct_sum, (), x.batch_size, x.shape, x.order)
 
@@ -592,7 +593,7 @@ def sum_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif x.ndim == 1:
         return _ct_sum_vector(x, axis)
     else:
-        ONPDimensionError(f"The dimension is invalid = {x.ndims}")
+        raise ONPDimensionError(f"The dimension is invalid = {x.ndims}")
 
 
 # ------------------------------------------------------------------------------
@@ -612,7 +613,7 @@ def mean_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif axis == 1:  # sum over cols
         ct_mean = cc.EvalMult(sum_x.data, 1.0 / ncols)
     else:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
 
     return CTArray(
         ct_mean,
@@ -633,7 +634,7 @@ def roll(x: ArrayLike, shift: int, axis: Optional[int] = None) -> ArrayLike:
     if axis is None:
         return _ct_vector_rotation(x, -shift)
     else:
-        ONP_ERROR(f"This function only supports packed vector")
+        raise ONPError(f"This function only supports packed vector")
 
 
 def _ct_vector_rotation(ctv: CTArray, shift: int):

--- a/openfhe_numpy/tensor/__init__.py
+++ b/openfhe_numpy/tensor/__init__.py
@@ -6,6 +6,7 @@ from .ptarray import PTArray
 from .ctarray import CTArray
 from .block_tensor import BlockFHETensor
 from .block_ctarray import BlockCTArray
+from .block_ptarray import BlockPTArray
 
 
 # Import tensor constructors
@@ -19,8 +20,6 @@ __all__ = [
     "CTArray",
     "BlockFHETensor",
     "BlockCTArray",
+    "BlockPTArray",
     "array",
 ]
-
-
-# _register_all_operations()

--- a/openfhe_numpy/tensor/block_ptarray.py
+++ b/openfhe_numpy/tensor/block_ptarray.py
@@ -29,54 +29,36 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
-
 from __future__ import annotations
-
 import numpy as np
-from openfhe import Ciphertext
 
-from ..utils.constants import UnpackType
+from openfhe import Plaintext
 from .block_tensor import BlockFHETensor
 
 
-class BlockCTArray(BlockFHETensor[Ciphertext]):
-    """Block tensor of encrypted blocks (CTArray).
+class BlockPTArray(BlockFHETensor[Plaintext]):
+    """Block tensor of plaintext blocks (PTArray).
 
-    This is a thin subclass. All storage, indexing, and metadata
-    logic lives in BlockFHETensor. BlockCTArray adds only:
-
-        - is_encrypted = True
-        - decrypt()
-        - higher tensor_priority for dispatch
+    All storage, indexing, and metadata logic lives in BlockFHETensor.
+    BlockPTArray adds plaintext decoding and a higher tensor priority than
+    PTArray for dispatch.
     """
 
-    tensor_priority = 40
-    is_encrypted = True
+    tensor_priority = 35
+    is_encrypted = False
 
-    def decrypt(
-        self,
-        secret_key,
-        unpack_type: UnpackType = UnpackType.ORIGINAL,
-        new_shape=None,
-    ) -> np.ndarray:
-        """Decrypt all blocks and return a NumPy array with original_shape."""
-        if isinstance(unpack_type, str):
-            unpack_type = UnpackType(unpack_type.lower())
+    def decrypt(self, *args, **kwargs) -> np.ndarray:
+        raise NotImplementedError(
+            "Decrypt is not defined for plaintext block arrays. Use decode()."
+        )
 
-        if unpack_type != UnpackType.ORIGINAL:
-            raise NotImplementedError(
-                "BlockCTArray.decrypt currently supports only unpack_type='original'."
-            )
+    def decode(self) -> np.ndarray:
+        """Decode all blocks and reassemble the original logical array.
 
+        Returns a NumPy array with shape == original_shape.
+        """
         if self.ndim == 1:
-            if new_shape is not None:
-                raise NotImplementedError("new_shape is not supported for 1-D BlockCTArray.")
-            chunks = [
-                np.asarray(block.decrypt(secret_key, unpack_type=unpack_type)).reshape(
-                    self.block_shape
-                )
-                for block in self.data
-            ]
+            chunks = [np.asarray(block.decode()).reshape(self.block_shape) for block in self.data]
             full = np.concatenate(chunks)
             return full[: self.original_shape[0]]
 
@@ -89,16 +71,9 @@ class BlockCTArray(BlockFHETensor[Ciphertext]):
         for gi in range(grid_rows):
             for gj in range(grid_cols):
                 block = self.get_block(gi, gj)
-                plain = np.asarray(block.decrypt(secret_key, unpack_type=unpack_type)).reshape(
-                    self.block_shape
-                )
-                r0, c0 = gi * br, gj * bc
+                plain = np.asarray(block.decode()).reshape(self.block_shape)
+                r0 = gi * br
+                c0 = gj * bc
                 full[r0 : r0 + br, c0 : c0 + bc] = plain
 
-        if new_shape is not None:
-            return full[:rows, :cols].reshape(new_shape)
         return full[:rows, :cols]
-
-    def __neg__(self) -> BlockCTArray:
-        """Return the blockwise homomorphic negation."""
-        return self.clone(data=[-block for block in self.data])

--- a/openfhe_numpy/tensor/block_tensor.py
+++ b/openfhe_numpy/tensor/block_tensor.py
@@ -29,31 +29,628 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
-from typing import Generic
+from __future__ import annotations
+
+from math import prod
+from typing import Any, Generic, TypeVar
+from operator import index as operator_index
+
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from .tensor import FHETensor, TPL
+from .tensor import BaseTensor
 
 
-class BlockFHETensor(FHETensor[TPL], Generic[TPL]):
-    """Base class for block tensor implementations"""
+TPL = TypeVar("TPL")
+
+# =============================================================================
+# Block tensor base class
+# =============================================================================
+
+
+class BlockFHETensor(BaseTensor, Generic[TPL]):
+    """Base class for block-encoded FHE tensors.
+
+    A block tensor stores a logical 1-D or 2-D tensor as a flat row-major list of
+    encoded blocks. Each block stores a local chunk of the tensor, and the block
+    grid describes how those chunks tile the padded logical shape.
+
+    Parameters
+    ----------
+    data : list[Any] | tuple[Any, ...]
+        Flat row-major sequence of encoded blocks. Nested block lists are not
+        accepted here;  construction should use ``block_array(...)``.
+    block_shape : tuple[int, ...]
+        Logical shape of each encoded block. Only 1-D and 2-D blocks are
+        currently supported.
+    original_shape : tuple[int, ...]
+        Shape requested by the user before block padding.
+    batch_size : int
+        Number of plaintext slots available to each encoded block.
+    order : ArrayEncodingType, default=ArrayEncodingType.ROW_MAJOR
+        Packing order used by the encoded blocks.
+    grid_shape : tuple[int, ...] | None, default=None
+        Shape of the block grid. For 1-D block tensors, this is inferred from
+        ``len(data)`` when omitted. For 2-D block tensors, it must be provided.
+
+    Notes
+    -----
+    The padded tensor shape is computed as ``grid_shape * block_shape`` elementwise.
+    Thus, mathematically, if ``grid_shape = g`` and ``block_shape = b``, then
+    ``shape[i] = g[i] * b[i]``. The original logical shape must fit inside this
+    padded shape.
+
+    Limitations
+    -----------
+    - Only 1-D vectors and 2-D matrices are supported.
+    - Logical slicing/rotation/broadcasting is not implemented yet.
+
+    Subclasses declare encryption status using the class attribute:
+    ``is_encrypted = True`` for ciphertext block arrays and ``False`` for
+    plaintext block arrays.
+    """
+
+    tensor_priority = 30
+    is_encrypted: bool = False
+    __hash__ = None
 
     def __init__(
         self,
-        blocks,
-        block_shape,
-        original_shape,
-        batch_size,
-        ncols=1,
-        order=ArrayEncodingType.ROW_MAJOR,
-    ):
-        self._blocks = blocks
+        data: list[Any] | tuple[Any, ...],
+        block_shape: tuple[int, ...],
+        original_shape: tuple[int, ...],
+        batch_size: int,
+        order: ArrayEncodingType = ArrayEncodingType.ROW_MAJOR,
+        grid_shape: tuple[int, ...] | None = None,
+    ) -> None:
+        """Initialize a low-level block tensor from flat block storage.
+        This constructor validates only structural metadata.
+        Raises
+        ------
+        ValueError
+            If the block list is empty, nested, dimensionally inconsistent, or
+            cannot fit ``original_shape`` into the padded block layout.
+        """
+        if not isinstance(data, (list, tuple)):
+            raise ValueError("BlockFHETensor data must be a flat list/tuple of blocks.")
+
+        data = list(data)
+
+        if len(data) == 0:
+            raise ValueError("Block storage cannot be empty.")
+
+        if any(isinstance(block, (list, tuple)) for block in data):
+            raise ValueError(
+                "BlockFHETensor expects flat row-major block data. "
+                "Use block_array(...) for nested/user-facing input."
+            )
+
+        block_shape = tuple(block_shape)
+        original_shape = tuple(original_shape)
+
+        if grid_shape is None:
+            if len(block_shape) == 1:
+                grid_shape = (len(data),)
+            else:
+                raise ValueError("grid_shape is required for matrix BlockFHETensor.")
+
+        grid_shape = tuple(grid_shape)
+
+        self._validate_metadata(
+            data=data,
+            block_shape=block_shape,
+            original_shape=original_shape,
+            batch_size=batch_size,
+            grid_shape=grid_shape,
+        )
+
+        padded_shape = tuple(
+            grid_dim * block_dim for grid_dim, block_dim in zip(grid_shape, block_shape)
+        )
+
+        self._data = data
+        self._original_shape = original_shape
+        self._batch_size = batch_size
+        self._shape = padded_shape
+        self._order = order
+        self._dtype = self.__class__.__name__
         self._block_shape = block_shape
-        super().__init__(None, original_shape, batch_size, ncols, order)
+        self._grid_shape = grid_shape
+
+    @staticmethod
+    def _validate_metadata(
+        data: list[Any],
+        block_shape: tuple[int, ...],
+        original_shape: tuple[int, ...],
+        batch_size: int,
+        grid_shape: tuple[int, ...],
+    ) -> None:
+        """Validate block-grid metadata.
+
+        Checks that ranks agree, dimensions are positive, each block fits in the
+        available slot capacity, the number of blocks matches ``grid_shape``, and
+        ``original_shape`` fits inside the padded shape.
+        """
+        if len(block_shape) not in (1, 2):
+            raise ValueError(f"Only 1D/2D block tensors are supported; got {block_shape}.")
+        if len(original_shape) not in (1, 2):
+            raise ValueError(f"Only 1D/2D tensors are supported; got {original_shape}.")
+        if len(block_shape) != len(original_shape):
+            raise ValueError(
+                f"block_shape rank must equal original_shape rank; "
+                f"got {block_shape} and {original_shape}."
+            )
+        if len(grid_shape) != len(block_shape):
+            raise ValueError(
+                f"grid_shape rank must equal block_shape rank; got {grid_shape} and {block_shape}."
+            )
+        if any(dim <= 0 for dim in block_shape):
+            raise ValueError(f"block_shape must be positive; got {block_shape}.")
+        if any(dim <= 0 for dim in original_shape):
+            raise ValueError(f"original_shape must be positive; got {original_shape}.")
+        if any(dim <= 0 for dim in grid_shape):
+            raise ValueError(f"grid_shape must be positive; got {grid_shape}.")
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive; got {batch_size}.")
+
+        block_slots = prod(block_shape)
+        if block_slots > batch_size:
+            raise ValueError(
+                f"block_shape={block_shape} requires {block_slots} slots, "
+                f"but batch_size={batch_size}."
+            )
+
+        expected_blocks = prod(grid_shape)
+        if len(data) != expected_blocks:
+            raise ValueError(
+                f"grid_shape={grid_shape} expects {expected_blocks} blocks, but got {len(data)}."
+            )
+
+        padded_shape = tuple(g * b for g, b in zip(grid_shape, block_shape))
+        if any(orig > pad for orig, pad in zip(original_shape, padded_shape)):
+            raise ValueError(
+                f"original_shape={original_shape} cannot exceed padded_shape={padded_shape}."
+            )
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
 
     @property
-    def blocks(self):
-        return self._blocks
+    def data(self) -> list[Any]:
+        """Flat row-major list of encoded blocks."""
+        return self._data
+
+    @data.setter
+    def data(self, value: Any) -> None:
+        """Replace the internal block list without revalidating metadata."""
+        self._data = value
 
     @property
-    def block_shape(self):
+    def original_shape(self) -> tuple[int, ...]:
+        """Logical tensor shape before block padding."""
+        return self._original_shape
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Padded logical shape covered by the block grid."""
+        return self._shape
+
+    @property
+    def batch_size(self) -> int:
+        """Number of plaintext slots available per encoded block."""
+        return self._batch_size
+
+    @property
+    def order(self) -> ArrayEncodingType:
+        """Packing order used by the encoded blocks."""
+        return self._order
+
+    @property
+    def dtype(self) -> str:
+        """Tensor dtype name, currently the concrete class name."""
+        return self._dtype
+
+    @property
+    def ndim(self) -> int:
+        """Number of logical tensor dimensions."""
+        return len(self._original_shape)
+
+    @property
+    def ncols(self) -> int | None:
+        """Number of padded columns for a matrix, or ``None`` for vectors."""
+        if self.ndim == 2:
+            return self._shape[1]
+        return None
+
+    @property
+    def block_shape(self) -> tuple[int, ...]:
+        """Logical shape of each encoded block."""
         return self._block_shape
+
+    @property
+    def grid_shape(self) -> tuple[int, ...]:
+        """Shape of the block grid."""
+        return self._grid_shape
+
+    @property
+    def block_ndim(self) -> int:
+        """Number of dimensions inside each block."""
+        return len(self._block_shape)
+
+    @property
+    def block_size(self) -> int:
+        """Number of logical entries represented by one block."""
+        return prod(self._block_shape)
+
+    @property
+    def num_blocks(self) -> int:
+        """Total number of encoded blocks."""
+        return len(self._data)
+
+    @property
+    def is_vector(self) -> bool:
+        """Whether this block tensor is logically 1-D."""
+        return self.ndim == 1
+
+    @property
+    def is_matrix(self) -> bool:
+        """Whether this block tensor is logically 2-D."""
+        return self.ndim == 2
+
+    @property
+    def logical_size(self) -> int:
+        """Number of entries in the unpadded logical tensor."""
+        return prod(self._original_shape)
+
+    @property
+    def padded_size(self) -> int:
+        """Number of entries in the padded logical tensor."""
+        return prod(self._shape)
+
+    @property
+    def total_slot_capacity(self) -> int:
+        """Total slot capacity across all blocks."""
+        return self.num_blocks * self._batch_size
+
+    @property
+    def slot_utilization(self) -> float:
+        """Fraction of total block slot capacity used by logical entries."""
+        return self.logical_size / self.total_slot_capacity
+
+    @property
+    def padding_overhead(self) -> float:
+        """Fraction of padded logical entries outside ``original_shape``."""
+        return 1.0 - (self.logical_size / self.padded_size)
+
+    @property
+    def info(self) -> dict[str, Any]:
+        """Return a dictionary of layout and storage metadata."""
+        return {
+            "dtype": self._dtype,
+            "original_shape": self._original_shape,
+            "shape": self._shape,
+            "block_shape": self._block_shape,
+            "grid_shape": self._grid_shape,
+            "num_blocks": self.num_blocks,
+            "block_size": self.block_size,
+            "batch_size": self._batch_size,
+            "logical_size": self.logical_size,
+            "padded_size": self.padded_size,
+            "total_slot_capacity": self.total_slot_capacity,
+            "slot_utilization": self.slot_utilization,
+            "padding_overhead": self.padding_overhead,
+            "order": self._order,
+            "encrypted": self.is_encrypted,
+        }
+
+    # ------------------------------------------------------------------
+    # Block-grid indexing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_index(index: int, size: int, name: str) -> int:
+        """Normalize a possibly negative Python index."""
+        try:
+            index = operator_index(index)
+        except TypeError as exc:
+            raise TypeError(f"{name} must be an integer; got {index!r}.") from exc
+
+        if index < 0:
+            index += size
+        if index < 0 or index >= size:
+            raise IndexError(f"{name} {index} out of range for size={size}.")
+        return index
+
+    def _block_offset(self, grid_index: tuple[int, ...]) -> int:
+        """Convert a block-grid index to a flat row-major block offset."""
+        if len(grid_index) != len(self._grid_shape):
+            raise IndexError(
+                f"Expected {len(self._grid_shape)} block index value(s), got {len(grid_index)}."
+            )
+
+        if len(self._grid_shape) == 1:
+            i = self._normalize_index(grid_index[0], self._grid_shape[0], "Block index")
+            return i
+
+        i, j = grid_index
+        rows, cols = self._grid_shape
+        i = self._normalize_index(i, rows, "Block row")
+        j = self._normalize_index(j, cols, "Block column")
+        return i * cols + j
+
+    def get_block(self, *grid_index) -> Any:
+        """Return a block by block-grid index.
+
+        The index may be passed either as separate integers, e.g.
+        ``get_block(i, j)``, or as one tuple, e.g. ``get_block((i, j))``.
+        """
+        if len(grid_index) == 1 and isinstance(grid_index[0], tuple):
+            grid_index = grid_index[0]
+        return self._data[self._block_offset(tuple(grid_index))]
+
+    def get_block_row(self, i: int) -> list[Any]:
+        """Return all blocks in block row ``i``."""
+        if self.ndim != 2:
+            raise ValueError("get_block_row is only valid for block matrices.")
+        rows, cols = self._grid_shape
+        i = self._normalize_index(i, rows, "Block row")
+        start = i * cols
+        return self._data[start : start + cols]
+
+    def get_block_col(self, j: int) -> list[Any]:
+        """Return all blocks in block column ``j``."""
+        if self.ndim != 2:
+            raise ValueError("get_block_col is only valid for block matrices.")
+        rows, cols = self._grid_shape
+        j = self._normalize_index(j, cols, "Block column")
+        return [self._data[i * cols + j] for i in range(rows)]
+
+    def iter_block_indices(self):
+        """Yield block-grid indices in row-major order."""
+        if self.ndim == 1:
+            for i in range(self._grid_shape[0]):
+                yield (i,)
+        else:
+            rows, cols = self._grid_shape
+            for i in range(rows):
+                for j in range(cols):
+                    yield (i, j)
+
+    def block_grid(self) -> list[Any]:
+        """Return a nested block view for debugging and inspection.
+
+        The returned containers are new Python lists, but block objects are not
+        copied.
+        """
+        if self.ndim == 1:
+            return list(self._data)
+        rows, cols = self._grid_shape
+        return [self._data[i * cols : (i + 1) * cols] for i in range(rows)]
+
+    # ------------------------------------------------------------------
+    # Logical indexing
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Return the length of the first logical dimension."""
+        return self._original_shape[0]
+
+    def __getitem__(self, key):
+        """Return a logical scalar entry by integer index.
+
+        Negative integer indices follow Python indexing convention.
+
+        Limitations
+        -----------
+        - Slice indexing is not implemented.
+        - Only scalar logical entries are supported.
+        - Actual extraction depends on whether the encoded block implements
+          ``__getitem__``.
+        """
+        if isinstance(key, slice) or (
+            isinstance(key, tuple) and any(isinstance(k, slice) for k in key)
+        ):
+            raise NotImplementedError(
+                "Logical slicing is not implemented yet. "
+                "Use get_block_row/get_block_col for block-level access."
+            )
+        return self._get_logical_entry(key)
+
+    def get_entry(self, *key):
+        """Return a logical scalar entry.
+
+        This is a convenience wrapper around ``__getitem__`` that accepts either
+        ``get_entry(i)`` for vectors or ``get_entry(i, j)`` for matrices.
+        """
+        if len(key) == 0:
+            raise IndexError("BlockFHETensor does not support scalar indexing.")
+        if len(key) == 1:
+            return self[key[0]]
+        return self[tuple(key)]
+
+    def _locate_index(self, key) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Map a logical index to ``(block_index, local_index)``."""
+        if self.ndim == 1:
+            if isinstance(key, tuple):
+                if len(key) != 1:
+                    raise IndexError(f"Expected one index for vector, got {key}.")
+                key = key[0]
+
+            i = self._normalize_index(key, self._original_shape[0], "Index")
+            b = self._block_shape[0]
+            return (i // b,), (i % b,)
+
+        if self.ndim == 2:
+            if not isinstance(key, tuple) or len(key) != 2:
+                raise IndexError(f"Expected two indices for matrix, got {key}.")
+
+            i, j = key
+            nrows, ncols = self._original_shape
+            i = self._normalize_index(i, nrows, "Row index")
+            j = self._normalize_index(j, ncols, "Column index")
+
+            br, bc = self._block_shape
+            return (i // br, j // bc), (i % br, j % bc)
+
+        raise ValueError(f"Unsupported ndim={self.ndim}.")
+
+    def _get_logical_entry(self, key):
+        """Extract a logical entry from the selected encoded block.
+
+        This helper performs index mapping only. The concrete block type is
+        responsible for supporting local ``__getitem__`` extraction.
+        """
+        block_index, local_index = self._locate_index(key)
+        block = self.get_block(*block_index)
+        if not hasattr(block, "__getitem__"):
+            raise NotImplementedError(
+                "Block object does not support __getitem__. "
+                f"block_type={type(block).__name__}, local_index={local_index}."
+            )
+        try:
+            return block[local_index]
+        except Exception as exc:
+            raise NotImplementedError(
+                "Logical entry extraction from an encoded block failed. "
+                f"Unsupported local_index={local_index}."
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Operator dispatch
+    # ------------------------------------------------------------------
+
+    def __add__(self, other):
+        """Return ``self + other`` through tensor dispatch."""
+        return self.__tensor_function__("add", (self, other))
+
+    def __radd__(self, other):
+        """Return ``other + self`` through tensor dispatch."""
+        return self.__tensor_function__("add", (other, self))
+
+    def __sub__(self, other):
+        """Return ``self - other`` through tensor dispatch."""
+        return self.__tensor_function__("subtract", (self, other))
+
+    def __rsub__(self, other):
+        """Return ``other - self`` through tensor dispatch."""
+        return self.__tensor_function__("subtract", (other, self))
+
+    def __mul__(self, other):
+        """Return element-wise ``self * other`` through tensor dispatch."""
+        return self.__tensor_function__("multiply", (self, other))
+
+    def __rmul__(self, other):
+        """Return element-wise ``other * self`` through tensor dispatch."""
+        return self.__tensor_function__("multiply", (other, self))
+
+    def __matmul__(self, other):
+        """Return ``self @ other`` through tensor dispatch."""
+        return self.__tensor_function__("matmul", (self, other))
+
+    def __pow__(self, exp):
+        """Return matrix power ``self ** exp`` through tensor dispatch."""
+        return self.__tensor_function__("pow", (self, exp))
+
+    @property
+    def T(self):
+        """Transpose view/result, equivalent to ``self.transpose()``."""
+        return self.transpose()
+
+    def sum(self, axis=None, keepdims: bool = False):
+        """Sum block tensor entries through tensor dispatch."""
+        return self.__tensor_function__("sum", (self,), {"axis": axis, "keepdims": keepdims})
+
+    def cumsum(self, axis=None, keepdims: bool = False):
+        """Compute cumulative sums through tensor dispatch."""
+        return self.__tensor_function__("cumsum", (self,), {"axis": axis, "keepdims": keepdims})
+
+    def transpose(self):
+        """Transpose the block tensor through tensor dispatch.
+
+        For 1-D tensors, this follows NumPy behavior and returns the tensor
+        unchanged.
+        """
+        return self.__tensor_function__("transpose", (self,))
+
+    def cumulative_reduce(self, axis: int = 0, keepdims: bool = False):
+        """Compute backend-specific cumulative reduction through dispatch.
+
+        This is an FHE-specific operation, not a direct NumPy API equivalent.
+        """
+        return self.__tensor_function__(
+            "cumulative_reduce", (self,), {"axis": axis, "keepdims": keepdims}
+        )
+
+    def __tensor_function__(self, func_name, args, kwargs=None, verbose: bool = False):
+        """Dispatch tensor operations via the registry."""
+        from openfhe_numpy.operations.dispatch import dispatch_tensor_function
+
+        return dispatch_tensor_function(func_name, args, kwargs or {}, verbose=verbose)
+
+    # ------------------------------------------------------------------
+    # Copy / equality / repr
+    # ------------------------------------------------------------------
+
+    def clone(self, data: list[Any] | None = None) -> BlockFHETensor:
+        """Return a shallow copy, optionally with new block data.
+
+        Metadata is preserved. Block objects are not deep-copied unless the
+        caller supplies already-copied block data.
+        """
+        return self.__class__(
+            data=data if data is not None else list(self._data),
+            grid_shape=self._grid_shape,
+            block_shape=self._block_shape,
+            original_shape=self._original_shape,
+            batch_size=self._batch_size,
+            order=self._order,
+        )
+
+    def same_layout(self, other: Any) -> bool:
+        """Return ``True`` if layout metadata and encryption status match."""
+        attrs = (
+            "original_shape",
+            "shape",
+            "batch_size",
+            "order",
+            "block_shape",
+            "grid_shape",
+            "is_encrypted",
+        )
+        if not all(hasattr(other, attr) for attr in attrs):
+            return False
+
+        return (
+            self._original_shape == other.original_shape
+            and self._shape == other.shape
+            and self._batch_size == other.batch_size
+            and self._order == other.order
+            and self._block_shape == other.block_shape
+            and self._grid_shape == other.grid_shape
+            and self.is_encrypted == other.is_encrypted
+        )
+
+    def same_metadata(self, other: Any) -> bool:
+        """Return ``True`` if layout metadata, encryption status, and dtype match."""
+        return self.same_layout(other) and getattr(other, "dtype", None) == self._dtype
+
+    def __eq__(self, other: Any) -> bool:
+        """Return metadata-only equality.
+
+        This does not compare encoded block values. For encrypted tensors, value
+        equality is generally not directly observable without decryption.
+        """
+        return self.same_metadata(other)
+
+    def __repr__(self) -> str:
+        """Return a compact representation of block tensor metadata."""
+        return (
+            f"{self.__class__.__name__}("
+            f"original_shape={self._original_shape}, "
+            f"shape={self._shape}, "
+            f"block_shape={self._block_shape}, "
+            f"grid_shape={self._grid_shape}, "
+            f"num_blocks={self.num_blocks}, "
+            f"batch_size={self._batch_size}, "
+            f"slot_utilization={self.slot_utilization:.3f}, "
+            f"order={self._order})"
+        )

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -36,8 +36,10 @@ This module provides functions to create FHE array from various input types,
 including support for block-based tensor operations.
 """
 
+from __future__ import annotations
 # Third‐party imports
-from typing import Literal, Optional, Union
+from math import ceil, prod
+from typing import Any, Literal
 import numpy as np
 from openfhe import CryptoContext, PublicKey
 
@@ -59,49 +61,209 @@ from openfhe_numpy.utils.typecheck import (
 
 
 # Tensor imports
+from .tensor import FHETensor, PackedArrayInformation
 from .ctarray import CTArray
 from .ptarray import PTArray
-from .tensor import FHETensor, PackedArrayInformation
+from .block_tensor import BlockFHETensor
+from .block_ctarray import BlockCTArray
+from .block_ptarray import BlockPTArray
 
 
-def _get_block_dimensions(data: np.ndarray, slots: int) -> tuple[int, int]:
-    """
-    TODO: Compute the block‐matrix dimensions (rows, cols)
-    given raw `data` and number of slots.
-    """
-    pass
-
-
-def block_array(
-    cc: CryptoContext,
-    data: np.ndarray | Number | list,
-    batch_size: Optional[int] = None,
+def _shape(data: Any) -> tuple[int, ...]:
+    """Return NumPy-style shape."""
+    if isinstance(data, Number):
+        return ()
+    shape = getattr(data, "shape", None)
+    if shape is None:
+        shape = np.shape(data)
+    return tuple(shape)
+def _compute_block_dimensions(
+    shape: tuple[int, ...],
+    batch_size: int,
+    block_shape: tuple[int, ...] | None = None,
     order: int = ArrayEncodingType.ROW_MAJOR,
-    fhe_type: Literal["C", "P"] = "C",
+    target_cols: int | None = None,
+    compact: bool = False,
+) -> tuple[int, ...]:
+    """Choose block dimensions if block_shape is None.
+    Default rules:
+        Vector  (n,)    -> (batch_size,), or (side,) where
+                           side = 2^floor(log2(batch_size)/2) if compact=True
+        Column  (m, 1)  -> (batch_size, 1)
+        Row     (1, n)  -> (1, batch_size)
+        General (m, n)  -> (side, side) where side = 2^floor(log2(batch_size)/2)
+    ``compact=True`` requests the smaller, square-compatible vector block
+    size required to pair a block vector with a block matrix for block
+    matrix-vector multiplication (see ``block_array``'s ``compact``
+    parameter). Plain block vectors used for vector-vector arithmetic
+    (add/sub/multiply/dot/matmul) should use the default, non-compact sizing.
+    TODO:
+    [OPTIONAL] For rectangular matrices where one dimension fits in a single
+    block, use rectangular block_shape to reduce wasted slots.
+    """
+    if len(shape) not in (1, 2):
+        raise ValueError(f"Only 1-D or 2-D shapes are supported; got {shape}.")
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive; got {batch_size}.")
+    if any(dim <= 0 for dim in shape):
+        raise ValueError(f"shape must be positive; got {shape}.")
+    if block_shape is not None:
+        block_shape = tuple(block_shape)
+        if len(block_shape) != len(shape):
+            raise ValueError(
+                f"block_shape rank must match shape rank; "
+                f"got block_shape={block_shape}, shape={shape}."
+            )
+        if any(dim <= 0 for dim in block_shape):
+            raise ValueError(f"block_shape must be positive; got {block_shape}.")
+        if prod(block_shape) > batch_size:
+            raise ValueError(
+                f"block_shape={block_shape} uses {prod(block_shape)} slots, "
+                f"but batch_size={batch_size}."
+            )
+        if len(block_shape) == 2:
+            br, bc = block_shape
+            if not is_power_of_two(br) or not is_power_of_two(bc):
+                raise ValueError(
+                    f"Matrix block dimensions must be powers of two; got block_shape={block_shape}."
+                )
+        return block_shape
+    if target_cols is not None:
+        if len(shape) != 1:
+            raise ValueError("target_cols is only valid for block vectors.")
+        if not isinstance(target_cols, int) or target_cols <= 0:
+            raise ValueError(f"target_cols must be a positive integer, got {target_cols!r}.")
+        if target_cols > batch_size:
+            raise ValueError(f"target_cols={target_cols} exceeds batch_size={batch_size}.")
+        return (target_cols,)
+    if len(shape) == 1:
+        if not compact:
+            return (batch_size,)
+        side = 1 << ((batch_size.bit_length() - 1) // 2)
+        return (side,)
+    m, n = shape
+    if n == 1:
+        return (batch_size, 1)
+    if m == 1:
+        return (1, batch_size)
+    side = 1 << ((batch_size.bit_length() - 1) // 2)
+    return (side, side)
+
+
+def _compute_grid_shape(
+    original_shape: tuple[int, ...],
+    block_shape: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return the number of blocks along each dimension."""
+    if len(original_shape) != len(block_shape):
+        raise ValueError(
+            f"original_shape and block_shape must have the same rank; "
+            f"got original_shape={original_shape}, block_shape={block_shape}."
+        )
+    return tuple(ceil(s / b) for s, b in zip(original_shape, block_shape))
+def block_array(
+    cc,
+    data: np.ndarray | list,
+    block_shape: tuple | None = None,
+    batch_size: int | None = None,
+    order: int = ArrayEncodingType.ROW_MAJOR,
     mode: str = "tile",
-    package: Optional[dict] = None,
-    public_key: PublicKey = None,
-    **kwargs,
-) -> FHETensor:
+    fhe_type: Literal["C", "P"] = "C",
+    public_key=None,
+    target_cols: int | None = None,
+    compact: bool = False,
+) -> BlockFHETensor:
+    """Construct a block plaintext/ciphertext tensor.
+    Tiles the input into encoded blocks, zero-pads edge blocks, and
+    returns a BlockCTArray or BlockPTArray.
+    ``compact`` (vectors only) requests the duplicated, square-compatible
+    packing (e.g. ROW_MAJOR -> [x0, x0, x1, x1]) required to pair a block
+    vector with a block matrix for block matrix-vector multiplication.
+    Leave it False (default) for plain block-vector arithmetic
+    (add/sub/multiply/dot/matmul) -- compact packing duplicates each
+    element, which corrupts summation-based ops like dot/matmul if used
+    outside of block matvec. Passing an explicit ``target_cols`` implies
+    ``compact=True``.
+    For advanced users who already have encoded blocks, call
+    BlockCTArray(...) or BlockPTArray(...) directly.
     """
-    Construct a block‐plaintext or block‐ciphertext array from raw input.
+    if cc is None:
+        raise ValueError("CryptoContext is required.")
+    if fhe_type not in ("C", "P"):
+        raise ValueError(f"fhe_type must be 'C' or 'P'; got {fhe_type!r}.")
+    if fhe_type == "C" and public_key is None:
+        raise ValueError("public_key is required for encryption.")
 
-    Parameters
-    ----------
-    cc         : CryptoContext
-    data       : np.ndarray | Number | list
-    batch_size : Optional[int]
-    order      : ArrayEncodingType
-    type      : "C" for ciphertext, "P" for plaintext
-    mode       : padding mode ("tile" or "zero")
-    package    : Optional prepacked dict from `_pack_array`
-    public_key : PublicKey (required for encryption)
+    if batch_size is None:
+        batch_size = cc.GetBatchSize()
+    arr = np.asarray(data)
+    original_shape = arr.shape
+    if arr.ndim == 0:
+        raise ValueError("Scalar input not supported. Use array() instead.")
+    if arr.ndim > 2:
+        raise ValueError(f"Only 1-D and 2-D supported; got shape {arr.shape}.")
+    is_compact = compact or target_cols is not None
+    block_shape = _compute_block_dimensions(
+        original_shape,
+        batch_size,
+        block_shape,
+        order=order,
+        target_cols=target_cols,
+        compact=is_compact,
+    )
+    grid_shape = _compute_grid_shape(original_shape, block_shape)
+    block_cls = BlockCTArray if fhe_type == "C" else BlockPTArray
+    blocks = []
+    if arr.ndim == 1:
+        chunk = block_shape[0]
+        for i in range(grid_shape[0]):
+            start = i * chunk
+            stop = min(start + chunk, original_shape[0])
+            tile = np.zeros(block_shape, dtype=arr.dtype)
+            tile[: stop - start] = arr[start:stop]
+            # matrix-vector multiplication.
+            vector_target_cols = chunk if is_compact and chunk * chunk <= batch_size else None
+            blocks.append(
+                array(
+                    cc=cc,
+                    data=tile,
+                    batch_size=batch_size,
+                    order=order,
+                    mode=mode,
+                    fhe_type=fhe_type,
+                    public_key=public_key,
+                    target_cols=vector_target_cols,
+                )
+            )
+    else:
+        br, bc = block_shape
+        for gi in range(grid_shape[0]):
+            r0, r1 = gi * br, min((gi + 1) * br, original_shape[0])
+            for gj in range(grid_shape[1]):
+                c0, c1 = gj * bc, min((gj + 1) * bc, original_shape[1])
+                tile = np.zeros(block_shape, dtype=arr.dtype)
+                tile[: r1 - r0, : c1 - c0] = arr[r0:r1, c0:c1]
+                blocks.append(
+                    array(
+                        cc=cc,
+                        data=tile,
+                        batch_size=batch_size,
+                        order=order,
+                        mode=mode,
+                        fhe_type=fhe_type,
+                        public_key=public_key,
+                    )
+                )
 
-    Returns
-    -------
-    FHETensor
-    """
-    pass
+    return block_cls(
+        data=blocks,
+        grid_shape=grid_shape,
+        block_shape=block_shape,
+        original_shape=original_shape,
+        batch_size=batch_size,
+        order=order,
+    )
+
 
 
 def _pack_array(
@@ -176,11 +338,11 @@ def _pack_array(
 def array(
     cc: CryptoContext,
     data: np.ndarray | Number | list,
-    batch_size: Optional[int] = None,
+    batch_size: int | None = None,
     order: int = ArrayEncodingType.ROW_MAJOR,
     fhe_type: Literal["C", "P"] = "P",
     mode: str = "tile",
-    package: Optional[PackedArrayInformation] = None,
+    package: PackedArrayInformation | None = None,
     public_key: PublicKey = None,
     **kwargs,
 ) -> FHETensor:
@@ -209,7 +371,7 @@ def array(
     if not isinstance(batch_size, int) or batch_size < 0:
         raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
-    if not package:
+    if package is None:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
 
     try:
@@ -277,10 +439,9 @@ def _ravel_matrix(
 
     if order == ArrayEncodingType.ROW_MAJOR:
         return _pack_matrix_row_wise(data, batch_size, pad_to_pow2, mode)
-    elif order == ArrayEncodingType.COL_MAJOR:
+    if order == ArrayEncodingType.COL_MAJOR:
         return _pack_matrix_col_wise(data, batch_size, pad_to_pow2, mode)
-    else:
-        raise ValueError("Unsupported encoding order")
+    raise ValueError(f"Unsupported encoding order: {order}")
 
 
 def _ravel_vector(
@@ -315,7 +476,7 @@ def _ravel_vector(
     """
     target_cols = kwargs.get("target_cols")
     if target_cols is not None and not (isinstance(target_cols, int) and target_cols > 0):
-        raise ONPError(f"target_cols must be positive int or None, got {target_cols!r}.")
+        raise ONPError(f"target_cols must be a positive int or None, got {target_cols!r}.")
 
     pad_value = kwargs.get("pad_value", "tile")
     expand = kwargs.get("expand", "tile")
@@ -330,8 +491,8 @@ def _ravel_vector(
             pad_to_power_of_2=pad_to_pow2,
             pad_value=pad_value,
         )
-    elif order == ArrayEncodingType.COL_MAJOR:
-        return _pack_vector_row_wise(
+    if order == ArrayEncodingType.COL_MAJOR:
+        return _pack_vector_col_wise(
             vector=data,
             batch_size=batch_size,
             target_cols=target_cols,
@@ -340,5 +501,4 @@ def _ravel_vector(
             pad_to_power_of_2=pad_to_pow2,
             pad_value=pad_value,
         )
-    else:
-        raise ONPError("Unsupported encoding order")
+    raise ONPError(f"Unsupported encoding order: {order}")

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -30,7 +30,7 @@
 # ==================================================================================
 
 """
-Array constructor functions for OpenFHE-NumPy.
+Constructor functions for OpenFHE-NumPy.
 
 This module provides functions to create FHE array from various input types,
 including support for block-based tensor operations.
@@ -43,7 +43,7 @@ from openfhe import CryptoContext, PublicKey
 
 # Package-level imports
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.matlib import is_power_of_two
 from openfhe_numpy.utils.packing import (
     _pack_matrix_col_wise,
@@ -136,11 +136,11 @@ def _pack_array(
       - order          : int
     """
     if batch_size < 0:
-        ONP_ERROR("The batch size cannot be negative.")
+        raise ONPError("The batch size cannot be negative.")
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two.")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two.")
 
-    data = np.array(data)
+    data = np.asarray(data)
 
     if is_numeric_scalar(data):
         if mode == "zero":
@@ -149,7 +149,7 @@ def _pack_array(
         elif mode == "tile":
             packed = np.full(batch_size, data)
         else:
-            ONP_ERROR(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
+            raise ONPError(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
         shape = (batch_size, 1)
 
     elif is_numeric_arraylike(data):
@@ -158,10 +158,10 @@ def _pack_array(
         elif data.ndim == 1:
             packed, shape = _ravel_vector(data, batch_size, order, True, mode, **kwargs)
         else:
-            ONP_ERROR(f"Unsupported data dimension [{data.ndim}].")
+            raise ONPError(f"Unsupported data dimension [{data.ndim}].")
 
     else:
-        ONP_ERROR("Input is not numeric.")
+        raise ONPError("Input is not numeric.")
 
     return PackedArrayInformation(
         data=packed,
@@ -202,12 +202,12 @@ def array(
     FHETensor
     """
     if cc is None:
-        ONP_ERROR("CryptoContext does not exist")
+        raise ONPError("CryptoContext does not exist")
 
     if batch_size is None:
         batch_size = cc.GetBatchSize()
     if not isinstance(batch_size, int) or batch_size < 0:
-        ONP_ERROR(f"batch_size must be a non-negative int or None, got {batch_size}.")
+        raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
     if not package:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
@@ -215,7 +215,7 @@ def array(
     try:
         plaintext = cc.MakeCKKSPackedPlaintext(package.data)
     except Exception as e:
-        ONP_ERROR("Error: " + str(e))
+        raise ONPError("Error: " + str(e))
 
     if fhe_type == "P":
         return PTArray(
@@ -227,7 +227,7 @@ def array(
         )
     elif fhe_type == "C":
         if public_key is None:
-            ONP_ERROR("Public key must be provided for ciphertext encoding.")
+            raise ONPError("Public key must be provided for ciphertext encoding.")
         try:
             ciphertext = cc.Encrypt(public_key, plaintext)
             return CTArray(
@@ -238,9 +238,9 @@ def array(
                 package.order,  # order
             )
         except Exception as e:
-            ONP_ERROR(f"Failed to encrypt: {e}")
+            raise ONPError(f"Failed to encrypt: {e}")
     else:
-        ONP_ERROR(f"type must be 'C' or 'P', got '{fhe_type}'.")
+        raise ONPError(f"type must be 'C' or 'P', got '{fhe_type}'.")
 
 
 def _ravel_matrix(
@@ -315,7 +315,7 @@ def _ravel_vector(
     """
     target_cols = kwargs.get("target_cols")
     if target_cols is not None and not (isinstance(target_cols, int) and target_cols > 0):
-        ONP_ERROR(f"target_cols must be positive int or None, got {target_cols!r}.")
+        raise ONPError(f"target_cols must be positive int or None, got {target_cols!r}.")
 
     pad_value = kwargs.get("pad_value", "tile")
     expand = kwargs.get("expand", "tile")
@@ -341,4 +341,4 @@ def _ravel_vector(
             pad_value=pad_value,
         )
     else:
-        ONP_ERROR("Unsupported encoding order")
+        raise ONPError("Unsupported encoding order")

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -38,7 +38,7 @@ import openfhe
 from ..openfhe_numpy import EvalSumCumCols, EvalSumCumRows, EvalTranspose, ArrayEncodingType
 from ..utils.matlib import next_power_of_two
 from ..utils.constants import UnpackType
-from ..utils.errors import ONP_ERROR
+from ..utils.errors import ONPError
 from ..utils.packing import process_packed_data
 from ..utils._helper_slots_ops import _get_single_element
 
@@ -243,12 +243,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             The decrypted data, formatted by 'unpack_type'.
         """
         if secret_key is None:
-            ONP_ERROR("Secret key is missing.")
+            raise ONPError("Secret key is missing.")
 
         cc = self.data.GetCryptoContext()
         plaintext = cc.Decrypt(self.data, secret_key)
         if plaintext is None:
-            ONP_ERROR("Decryption failed.")
+            raise ONPError("Decryption failed.")
 
         plaintext.SetLength(self.batch_size)
         result = plaintext.GetRealPackedValue()
@@ -269,7 +269,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
         stream = io.BytesIO()
         if not openfhe.Serialize(self.data, stream):
-            ONP_ERROR("Failed to serialize ciphertext.")
+            raise ONPError("Failed to serialize ciphertext.")
 
         return {
             "type": self.type,
@@ -294,12 +294,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         ]
         for key in required_keys:
             if key not in obj:
-                ONP_ERROR(f"Missing required key '{key}' in serialized object.")
+                raise ONPError(f"Missing required key '{key}' in serialized object.")
 
         stream = io.BytesIO(bytes.fromhex(obj["ciphertext"]))
         ciphertext = openfhe.Ciphertext()
         if not openfhe.Deserialize(ciphertext, stream):
-            ONP_ERROR("Failed to deserialize ciphertext.")
+            raise ONPError("Failed to deserialize ciphertext.")
 
         return cls(
             ciphertext,
@@ -353,13 +353,13 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
 
         if self.ndim != 1 and self.ndim != 2:
-            ONP_ERROR(f"Dimension of array {self.ndim} is illegal ")
+            raise ONPError(f"Dimension of array {self.ndim} is illegal ")
 
         if self.ndim != 1 and axis is None:
-            ONP_ERROR("axis=None not allowed for >1D")
+            raise ONPError("axis=None not allowed for >1D")
 
         if self.ndim == 2 and axis not in (0, 1):
-            ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+            raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
         order = self.order
         shape = self.shape
@@ -377,7 +377,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumCols(self.data, self.nrows)
 
             else:
-                raise ONP_ERROR(f"Not support this packing order [{self.order}].")
+                raise ONPError(f"Not support this packing order [{self.order}].")
 
         # cumulative_sum over cols
         elif axis == 1:
@@ -388,9 +388,9 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumRows(self.data, self.nrows, self.original_shape[0])
 
             else:
-                raise ONP_ERROR(f"Not support this packing order[{self.order}].")
+                raise ONPError(f"Not support this packing order[{self.order}].")
         else:
-            raise ONP_ERROR(f"Invalid axis [{axis}].")
+            raise ONPError(f"Invalid axis [{axis}].")
         return CTArray(ciphertext, original_shape, self.batch_size, shape, order)
 
     def gen_sum_row_key(self, secret_key: openfhe.PrivateKey) -> openfhe.EvalKey:

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -37,7 +37,7 @@ from typing import overload, Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 import numpy as np
 
 # Internal C++ module Imports
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.constants import *
 
 # -----------------------------------------------------------
@@ -162,7 +162,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             self.extra = {}
         else:
             if None in (original_shape, batch_size, new_shape):
-                ONP_ERROR(
+                raise ONPError(
                     "Raw form requires (data, original_shape, ndim, batch_size, shape[, order])"
                 )
             self._data = data
@@ -172,7 +172,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
 
             self._ndim = len(original_shape)
             if self._ndim > 2 or self._ndim < 0:
-                ONP_ERROR("Dimension is invalid!!!")
+                raise ONPError("Dimension is invalid!!!")
             self._order = order
             self._dtype = self.__class__.__name__
             self._zeros = None
@@ -209,7 +209,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         elif isinstance(data, openfhe.Plaintext):
             self._dtype = "PTArray"
         else:
-            ONP_ERROR(
+            raise ONPError(
                 "Object data is incorrect. \
                       Only support FHETensor only supports Ciphertext or Plaintext"
             )
@@ -274,7 +274,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         if order in ["R", "C"]:
             self._order = order
         else:
-            ONP_ERROR("Not support order [{order}]")
+            raise ONPError(f"Not support order [f{order}]")
 
     @property
     def is_encrypted(self) -> int:
@@ -296,6 +296,17 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     @property
     def T(self):
         return self.transpose()
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"original_shape={self.original_shape}, "
+            f"batch_size={self.batch_size}, "
+            f"shape={self.shape}, "
+            f"order={self.order}, "
+            f"ndim={self.ndim}, "
+            f"extra={self.extra})"
+        )
 
     ###
     ### Update properties in some specific cases

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -28,252 +28,288 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
-
 """Logging and error handling for OpenFHE-NumPy.
 
 This module provides:
-1. A configured logger with consistent log formatting
-2. Custom exceptions with stack trace information
-3. Convenience functions for logging at different levels
-4. Configuration management via environment variables
+1. A package-level logger for OpenFHE-NumPy.
+2. Custom exception classes for user-facing tensor errors.
+3. Convenience logging helpers.
+4. Optional logging configuration through environment variables.
 
-Environment Variables:
-    OPENFHE_DEBUG: Enable debug logging ("ON", "1", "TRUE")
-    OPENFHE_LOG_FORMAT: Custom log format string
-    OPENFHE_LOG_FILE: Path to log file (optional)
-    OPENFHE_LOG_MAX_SIZE: Maximum log file size in bytes
-    OPENFHE_LOG_BACKUP_COUNT: Number of backup log files
+Logging policy
+--------------
+Default behavior:
+    No logs are printed by OpenFHE-NumPy.
 
-Usage::
-    from openfhe_numpy.utils.errors import ONP_DEBUG, ONP_ERROR, ONP_WARNING
+If the user sets OPENFHE_DEBUG or OPENFHE_LOG_FILE:
+    OpenFHE-NumPy configures its own logging.
 
-    ONP_DEBUG("Processing data...")
-    ONP_WARNING("Unusual input detected")
-    if problem:
-        ONP_ERROR("Invalid input data")
+If the application configures logging itself:
+    OpenFHE-NumPy respects that configuration.
+
+Environment variables
+---------------------
+OPENFHE_DEBUG:
+    Enable debug logging when set to "ON", "1", "TRUE", or "YES".
+
+OPENFHE_LOG_FORMAT:
+    Custom logging format string.
+
+OPENFHE_LOG_FILE:
+    Optional path to a log file.
+
+OPENFHE_LOG_MAX_SIZE:
+    Maximum rotating log file size in bytes. Default: 10MB.
+
+OPENFHE_LOG_BACKUP_COUNT:
+    Number of rotated backup log files. Default: 5.
+
+Backward compatibility
+----------------------
+FP_ENABLE_DEBUG:
+    Also enables debug logging when set to "ON", "1", "TRUE", or "YES".
 """
 
-import inspect
-import os
+from __future__ import annotations
+
 import logging
-import threading
-import traceback
-from typing import Any, Dict
+import os
+import warnings
 from logging.handlers import RotatingFileHandler
-
-# === Configuration ===
-
-# Default configuration values
-DEFAULT_CONFIG = {
-    "enable_debug": False,
-    "log_format": "%(asctime)s - %(levelname)s - %(message)s",
-    "log_file": None,
-    "max_file_size": 10 * 1024 * 1024,  # 10MB
-    "backup_count": 5,
-}
+from typing import Optional
 
 
-def get_config() -> Dict[str, Any]:
-    """Get logging configuration from environment variables with defaults."""
-    return {
-        "enable_debug": os.getenv("OPENFHE_DEBUG", "OFF").upper() in ("ON", "1", "TRUE"),
-        "log_format": os.getenv("OPENFHE_LOG_FORMAT", DEFAULT_CONFIG["log_format"]),
-        "log_file": os.getenv("OPENFHE_LOG_FILE", DEFAULT_CONFIG["log_file"]),
-        "max_file_size": int(
-            os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_CONFIG["max_file_size"]))
-        ),
-        "backup_count": int(
-            os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_CONFIG["backup_count"]))
-        ),
-    }
+# =============================================================================
+# Logging configuration
+# =============================================================================
+
+LOGGER_NAME = "openfhe_numpy"
+
+_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_BACKUP_COUNT = 5
 
 
-# Load configuration (done once at module import time)
-_config = get_config()
+def _env_flag_enabled(name: str, default: str = "OFF") -> bool:
+    """Return True if an environment flag is enabled."""
+    return os.getenv(name, default).upper() in {"ON", "1", "TRUE", "YES"}
 
-# For backward compatibility
-ENABLE_DEBUG = _config["enable_debug"]
-if os.getenv("FP_ENABLE_DEBUG", "OFF").upper() == "ON":
-    ENABLE_DEBUG = True
-    _config["enable_debug"] = True
 
-_logger = None
-_logger_lock = threading.Lock()
+def debug_enabled() -> bool:
+    """Return whether OpenFHE-NumPy debug logging is enabled."""
+    return _env_flag_enabled("OPENFHE_DEBUG") or _env_flag_enabled("FP_ENABLE_DEBUG")
+
+
+def _explicit_logging_requested() -> bool:
+    """Return True if OpenFHE-NumPy should configure its own logging."""
+    return (
+        debug_enabled()
+        or os.getenv("OPENFHE_LOG_FILE") is not None
+        or os.getenv("OPENFHE_LOG_FORMAT") is not None
+    )
 
 
 def get_logger() -> logging.Logger:
-    """Thread-safe singleton logger with console + optional rotating file output."""
-    global _logger
-    if _logger is None:
-        with _logger_lock:
-            if _logger is None:
-                _logger = logging.getLogger("openfhe_numpy")
+    """Return the OpenFHE-NumPy package logger.
 
-                if not _logger.handlers:
-                    formatter = logging.Formatter(_config["log_format"])
+    By default, the logger is silent and uses ``NullHandler``. This is the
+    recommended behavior for open-source libraries: importing the package should
+    not unexpectedly print logs.
 
-                    # Rotating file handler (optional)
-                    log_file = _config["log_file"]
-                    if log_file:
-                        try:
-                            file_handler = RotatingFileHandler(
-                                log_file,
-                                maxBytes=_config["max_file_size"],
-                                backupCount=_config["backup_count"],
-                            )
-                            file_handler.setFormatter(formatter)
-                            _logger.addHandler(file_handler)
-                        except Exception as e:
-                            print(f"Warning: Could not set up file logging: {e}")
+    If ``OPENFHE_DEBUG``, ``FP_ENABLE_DEBUG``, ``OPENFHE_LOG_FILE``, or
+    ``OPENFHE_LOG_FORMAT`` is set, OpenFHE-NumPy configures its own handler.
 
-                    # Console handler
-                    stream_handler = logging.StreamHandler()
-                    stream_handler.setFormatter(formatter)
-                    stream_handler.setLevel(
-                        logging.DEBUG if _config["enable_debug"] else logging.INFO
-                    )
-                    _logger.addHandler(stream_handler)
+    If an application has already configured the ``openfhe_numpy`` logger, this
+    function leaves that configuration unchanged.
+    """
+    logger = logging.getLogger(LOGGER_NAME)
 
-                    _logger.setLevel(logging.DEBUG)
-                    _logger.propagate = False
-    return _logger
+    # Respect application/test configuration.
+    if logger.handlers:
+        return logger
+
+    if not _explicit_logging_requested():
+        logger.addHandler(logging.NullHandler())
+        logger.propagate = True
+        return logger
+
+    handler_level = logging.DEBUG if debug_enabled() else logging.INFO
+    log_format = os.getenv("OPENFHE_LOG_FORMAT", _LOG_FORMAT)
+    formatter = logging.Formatter(log_format)
+
+    # Console handler is enabled only when logging is explicitly requested.
+    if debug_enabled() or os.getenv("OPENFHE_LOG_FORMAT") is not None:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(handler_level)
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
+
+    # Optional rotating file handler.
+    log_file = os.getenv("OPENFHE_LOG_FILE")
+    if log_file:
+        try:
+            max_file_size = int(os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_MAX_FILE_SIZE)))
+            backup_count = int(os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_BACKUP_COUNT)))
+
+            file_handler = RotatingFileHandler(
+                log_file,
+                maxBytes=max_file_size,
+                backupCount=backup_count,
+            )
+            file_handler.setLevel(handler_level)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+        except Exception as exc:
+            warnings.warn(
+                f"Could not set up OpenFHE-NumPy file logging: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    # Keep logger permissive; handlers decide what to emit.
+    logger.setLevel(logging.DEBUG)
+
+    # Avoid duplicate messages through the root logger once we add handlers.
+    logger.propagate = False
+
+    return logger
 
 
-# === Custom Exceptions ===
+logger = get_logger()
+
+
+# =============================================================================
+# Custom exceptions
+# =============================================================================
 
 
 class ONPError(Exception):
-    """Base class for OpenFHE-NumPy errors."""
-
-    def __init__(self, message: str):
-        stack = traceback.extract_stack(limit=2)[-2]
-        filename = os.path.basename(stack.filename)
-        function_name = stack.name
-        line_number = stack.lineno
-        full_message = f'{message}\n    File: "{filename}", line {line_number}, in {function_name}'
-        super().__init__(full_message)
+    """Base class for all OpenFHE-NumPy errors."""
 
 
 class ONPTypeError(ONPError, TypeError):
-    """Raised when incorrect types are provided."""
-
-    pass
+    """Raised when an object has an invalid type."""
 
 
 class ONPDimensionError(ONPError, ValueError):
-    """Raised when an invalid axis is provided."""
-
-    pass
+    """Raised when a tensor dimension, rank, or axis is invalid."""
 
 
 class ONPValueError(ONPError, ValueError):
     """Raised when an invalid value is encountered."""
 
-    def __init__(self, message: str = "Invalid value encountered."):
+    def __init__(self, message: str = "Invalid value encountered.") -> None:
         super().__init__(message)
 
 
-class ONPIncompatibleShape(ONPValueError, ValueError):
-    """Raised when tensor shapes are incompatible."""
+class ONPIncompatibleShapeError(ONPError, ValueError):
+    """Raised when tensor shapes are incompatible for an operation."""
 
-    def __init__(self, shape_a, shape_b, message: str = None):
+    def __init__(
+        self,
+        shape_a: object,
+        shape_b: object,
+        message: Optional[str] = None,
+    ) -> None:
         if message is None:
             message = f"Incompatible shapes: {shape_a} vs {shape_b}"
         super().__init__(message)
 
 
 class ONPNotImplementedError(ONPError, NotImplementedError):
-    """Raised when a feature is not implemented."""
+    """Raised when a feature is not yet implemented."""
 
-    def __init__(self, message: str = "This feature is not implemented."):
-        super().__init__(f"{message}")
+    def __init__(self, message: str = "This feature is not implemented.") -> None:
+        super().__init__(message)
 
 
 class ONPNotSupportedError(ONPError, NotImplementedError):
-    """Raised when a feature is not supported."""
+    """Raised when a feature is intentionally not supported."""
 
-    def __init__(self, message: str = "This feature is not supported."):
-        super().__init__(f"{message}")
-
-
-# === Logging Helpers ===
+    def __init__(self, message: str = "This feature is not supported.") -> None:
+        super().__init__(message)
 
 
-def _format_log(level: str, message: str, stack_level: int = 2) -> str:
-    frame = inspect.stack()[stack_level]
-    filename = os.path.basename(frame.filename)
-    function_name = frame.function
-    line_number = frame.lineno
-    return f'[{level}] {message}\n    File: "{filename}", line {line_number}, in {function_name}'
-
-
-def _log(level: str, message: str, stack_level: int = 2) -> None:
-    formatted_message = _format_log(level, message, stack_level)
-    logger = get_logger()
-    if level == "ONP_ERROR":
-        logger.error(formatted_message)
-    elif level == "ONP_DEBUG" and ENABLE_DEBUG:
-        logger.debug(formatted_message)
-    elif level == "ONP_WARNING":
-        logger.warning(formatted_message)
-    elif level == "ONP_INFO":
-        logger.info(formatted_message)
-    else:
-        return
-
-
-# === Public API ===
+# =============================================================================
+# Logging helpers
+# =============================================================================
 
 
 def ONP_INFO(message: str) -> None:
-    _log("ONP_INFO", message)
-
-
-def ONP_ERROR(message: str, raise_exception: bool = True) -> None:
-    _log("ONP_ERROR", message)
-    if raise_exception:
-        raise ONPError(message)
+    """Log an informational message."""
+    logger.info(message, stacklevel=2)
 
 
 def ONP_DEBUG(message: str) -> None:
-    _log("ONP_DEBUG", message)
+    """Log a debug message.
+
+    Visibility is controlled by logger and handler levels.
+    """
+    logger.debug(message, stacklevel=2)
 
 
 def ONP_WARNING(message: str) -> None:
-    _log("ONP_WARNING", message)
+    """Log a warning message."""
+    logger.warning(message, stacklevel=2)
+
+
+def ONP_ERROR(message: str) -> None:
+    """Log an error message."""
+    logger.error(message, stacklevel=2)
+
+
+# =============================================================================
+# Testing helper
+# =============================================================================
 
 
 def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
-    """Capture logs for testing.
-
-    Returns a handler that collects logs for inspection in tests.
+    """Attach an in-memory log handler for tests.
 
     Parameters
     ----------
-    level : int, optional
-        Logging level to capture (default: logging.DEBUG)
+    level:
+        Logging level to capture.
 
     Returns
     -------
     logging.Handler
-        A handler with a 'messages' attribute containing captured log messages
+        A handler with a ``messages`` attribute containing formatted log records.
 
     Example
     -------
-    handler = capture_logs()
-    ONP_DEBUG("Test message")
-    assert "Test message" in handler.messages
+    >>> handler = capture_logs()
+    >>> ONP_DEBUG("test message")
+    >>> assert any("test message" in msg for msg in handler.messages)
     """
 
     class MemoryHandler(logging.Handler):
+        """Simple in-memory logging handler."""
+
         def __init__(self) -> None:
             super().__init__(level)
-            self.messages = []
+            self.messages: list[str] = []
 
         def emit(self, record: logging.LogRecord) -> None:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
+    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
-    get_logger().addHandler(handler)
+
+    test_logger = get_logger()
+
+    # Remove the default no-op handler in tests, if present.
+    test_logger.handlers = [
+        existing_handler
+        for existing_handler in test_logger.handlers
+        if not isinstance(existing_handler, logging.NullHandler)
+    ]
+
+    test_logger.addHandler(handler)
+
+    # Make sure debug messages can reach the test handler.
+    test_logger.setLevel(logging.DEBUG)
+
     return handler

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -295,17 +295,13 @@ def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
-    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
 
     test_logger = get_logger()
 
-    # Remove the default no-op handler in tests, if present.
-    test_logger.handlers = [
-        existing_handler
-        for existing_handler in test_logger.handlers
-        if not isinstance(existing_handler, logging.NullHandler)
-    ]
+    for existing_handler in list(test_logger.handlers):
+        if isinstance(existing_handler, logging.NullHandler):
+            test_logger.removeHandler(existing_handler)
 
     test_logger.addHandler(handler)
 

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -51,7 +51,7 @@ from numpy.typing import ArrayLike
 
 from openfhe_numpy.openfhe_numpy import *
 
-from .errors import ONP_ERROR
+from .errors import ONPError
 from .matlib import is_power_of_two, next_power_of_two
 from .typecheck import *
 
@@ -99,7 +99,7 @@ def _pack_vector_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If expand mode is invalid
@@ -117,7 +117,7 @@ def _pack_vector_row_wise(
     """
 
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -130,7 +130,7 @@ def _pack_vector_row_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     flattened = np.zeros(expanded_size, dtype=np.asarray(vector).dtype)
     if expand == "tile":
@@ -141,21 +141,21 @@ def _pack_vector_row_wise(
             for i in range(n):
                 flattened[i * ncols : (i + 1) * ncols] = vector[i]
         else:
-            ONP_ERROR(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
+            raise ONPError(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
     elif expand == "zero":
         flattened[np.arange(n) * target_cols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size < (expanded_size * tiles):
-        ONP_ERROR(
+        raise ONPError(
             f"Padded vector [{expanded_size} x {tiles}] is longer than the batch size [{batch_size}]"
         )
 
@@ -201,7 +201,7 @@ def _pack_vector_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If tile_mode is invalid
@@ -217,7 +217,7 @@ def _pack_vector_col_wise(
 
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -229,7 +229,7 @@ def _pack_vector_col_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     padded = np.zeros(nrows, dtype=vector.dtype)
     padded[:n] = vector
@@ -244,14 +244,14 @@ def _pack_vector_col_wise(
     elif expand == "zero":
         flattened[: n * ncols : ncols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     total_len = tiles * expanded_size
     output = np.zeros(batch_size, dtype=flattened.dtype)
@@ -300,12 +300,12 @@ def _pack_matrix_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If 'batch_size' is not a power of two, not divisible by the padded size,
         or insufficient to hold the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -325,13 +325,13 @@ def _pack_matrix_row_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -383,12 +383,12 @@ def _pack_matrix_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If batch_size is not a power of two, or if batch_size is not divisible by
         the required size, or if batch_size is insufficient for the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -408,13 +408,13 @@ def _pack_matrix_col_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -543,7 +543,7 @@ def _extract_matrix(data, info):
         tranposed = np.transpose(reshaped)
         return tranposed[: info["original_shape"][0], : info["original_shape"][1]]
     else:
-        ONP_ERROR("Order is not supported!!!")
+        raise ONPError("Order is not supported!!!")
         return None
 
 
@@ -572,8 +572,7 @@ def _extract_vector(data, info):
         elif info["order"] == COL_MAJOR:
             return reshaped[0, :original_row]
         else:
-            ONP_ERROR("Order is not supported!!!")
-            return None
+            raise ONPError("Order is not supported!!!")
     else:
         return data[0]
 

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -601,3 +601,9 @@ def process_packed_data(
         return _extract_matrix(data, info)
     else:
         return _extract_vector(data, info)
+def _is_row_major(order: Any) -> bool:
+    """Return True if ``order`` is row-major packing."""
+    return order == ArrayEncodingType.ROW_MAJOR
+def _is_col_major(order: Any) -> bool:
+    """Return True if ``order`` is column-major packing."""
+    return order == ArrayEncodingType.COL_MAJOR


### PR DESCRIPTION
## Purpose

Issue: #56 
This PR adds constructor support for creating block tensor arrays.

## Scope

This PR adds:

- `block_array(...)` construction support;
- packing helpers for splitting large logical arrays into encoded blocks;
- constructor logic for `BlockCTArray` and `BlockPTArray`.

## Out of scope

This PR does not add block arithmetics.
