### PR TITLE
Add block matrix arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ OpenFHE-NumPy currently supports the following operations:
 | `multiply`  | Element-wise multiplication | `onp.multiply(a, b)` or `a * b` |
 | `matmul`    | Matrix multiplication       | `onp.matmul(a, b)` or `a @ b`   |
 | `transpose` | Matrix transposition        | `onp.transpose(a)`              |
-| `cumulative_sum`    | Cumulative sum along axis   | `onp.cumulative_sum(a, axis)`           |
+| `cumsum`    | Cumulative sum along axis   | `onp.cumsum(a, axis)`           |
 | `power`     | Element-wise power          | `onp.power(a, exp)`             |
 | `dot`       | Dot product                 | `onp.dot(a, b)`                 |
 | `sum`       | Sum along axis              | `onp.sum(a, axis)`              |

--- a/examples/python/simple_vector_operations.py
+++ b/examples/python/simple_vector_operations.py
@@ -19,11 +19,11 @@ def validate_and_print_results(computed, expected, operation_name):
 def main():
     """
     Run a demonstration of homomorphic vector operations using OpenFHE-NumPy:
-      • addition
-      • subtraction
-      • transpose
-      • elementwise multiplication
-      • inner product via *
+      - addition
+      - subtraction
+      - transpose
+      - elementwise multiplication
+      - inner product via *
     """
     # Cryptographic setup
     mult_depth = 4
@@ -48,7 +48,7 @@ def main():
     # Sample input vectors
     vector_a = [1.0, 2.0, 3.0, 4.0, 5.0]
     vector_b = [4.0, 0.0, 1.0, 3.0, 6.0]
-    vector_c = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8]
+    vector_c = [1.1, 2.2, 3.3, 4.0, 5.5, 6.6, 7.7, 8.8]
 
     print("\nInput vectors")
     print("vector_a:", vector_a)
@@ -113,7 +113,7 @@ def main():
     onp.gen_transpose_keys(keys.secretKey, ctv_a)
     ctv_a_T = onp.transpose(ctv_a)
     res_T = ctv_a_T.decrypt(keys.secretKey, unpack_type="original")
-    validate_and_print_results(res_T, np.transpose(vector_a), f"Tranpose \n{vector_a}")
+    validate_and_print_results(res_T, np.transpose(vector_a), f"Transpose \n{vector_a}")
 
     # 4) Elementwise multiplication
     ctv_mul = ctv_a * ctv_b
@@ -124,13 +124,13 @@ def main():
         f"Elementwise multiplication \n{vector_a} \n{vector_b} ",
     )
 
-    # 5) Elementwise multiplication
+    # 5) Scalar multiplication
     ctv_mul_scalar = ctv_a * 7
     res_mul_scalar = ctv_mul_scalar.decrypt(keys.secretKey, unpack_type="original")
     validate_and_print_results(
         res_mul_scalar,
         np.multiply(vector_a, 7),
-        f"Scalar Multiplcation \n{vector_a} and 7",
+        f"Scalar Multiplication \n{vector_a} and 7",
     )
 
     # 6) Inner product

--- a/openfhe_numpy/cpp/lib/numpy_bindings.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_bindings.cpp
@@ -192,6 +192,15 @@ void bind_matrix_funcs(py::module& m) {
         py::arg("numRepeats"));
 
     m.def("EvalMatMulSquare",
+        [](const std::vector<double>& matrixA, ConstCiphertext<DCRTPoly>& matrixB, uint32_t numCols)
+        {
+            return EvalMatMulSquare(matrixA, matrixB, numCols);
+        },
+        py::arg("matrixA"),
+        py::arg("matrixB"),
+        py::arg("numCols"));
+
+    m.def("EvalMatMulSquare",
         [](ConstCiphertext<DCRTPoly>& matrixA, ConstCiphertext<DCRTPoly>& matrixB, uint32_t numCols)
         {
             return EvalMatMulSquare(matrixA, matrixB, numCols);

--- a/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
@@ -28,8 +28,9 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //==============================================================================
-#include "numpy_enc_matrix.h"
 
+#include <limits>
+#include "numpy_enc_matrix.h"
 #include "numpy_utils.h"
 
 using namespace lbcrypto;
@@ -46,23 +47,35 @@ namespace openfhe_numpy {
 * @param numRepeats   Optional offset used by PHI and PSI types.
 * @return std::vector<int32_t> List of rotation indices to be used for EvalRotateKeyGen.
 **/
-static std::vector<int32_t> GenLinTransIndices(uint32_t numCols, LinTransType type, uint32_t numRepeats = 0) {
-    if (numCols < 0) {
+static std::vector<int32_t> GenLinTransIndices(
+    uint32_t numCols,
+    LinTransType type,
+    uint32_t numRepeats = 0
+) {
+    if (numCols == 0) {
         OPENFHE_THROW("numCols must be positive");
     }
 
-    if (numCols > std::numeric_limits<int32_t>::max() / 2 ||  // conservative upper bound
-        numRepeats < 0 || numRepeats > std::numeric_limits<int32_t>::max() / 2) {
+    if (numCols > static_cast<uint32_t>(std::numeric_limits<int32_t>::max() / 2) ||
+        numRepeats > static_cast<uint32_t>(std::numeric_limits<int32_t>::max() / 2)) {
         OPENFHE_THROW("numCols or numRepeats too large");
     }
 
+    const int32_t nCols  = static_cast<int32_t>(numCols);
+    const int32_t repeats = static_cast<int32_t>(numRepeats);
+
+    if (numCols > static_cast<uint32_t>(std::numeric_limits<int32_t>::max() / numCols)) {
+        OPENFHE_THROW("numCols * numCols is too large");
+    }
+
+    const int32_t blockSize = nCols * nCols;
+
     std::vector<int32_t> rotationIndices;
-    int32_t nCols = static_cast<int32_t>(numCols);
 
     switch (type) {
         case LinTransType::SIGMA:
             // Generate indices from -numCols to numCols - 1
-            rotationIndices.reserve(2*nCols);
+            rotationIndices.reserve(2 * nCols);
             for (int32_t k = -nCols; k < nCols; ++k) {
                 rotationIndices.push_back(k);
             }
@@ -70,9 +83,12 @@ static std::vector<int32_t> GenLinTransIndices(uint32_t numCols, LinTransType ty
 
         case LinTransType::TAU:
             // Generate indices: 0, numCols, 2*numCols, ..., (numCols-1)*numCols
-            rotationIndices.reserve(nCols);
+            rotationIndices.reserve(2 * nCols - 1);
             for (int32_t k = 0; k < nCols; ++k) {
                 rotationIndices.push_back(nCols * k);
+                if (k != 0) {
+                    rotationIndices.push_back(nCols * k - blockSize);
+                }
             }
             break;
 
@@ -80,18 +96,22 @@ static std::vector<int32_t> GenLinTransIndices(uint32_t numCols, LinTransType ty
             // Generate indices: numRepeats, numRepeats - numCols
             rotationIndices.reserve(2);
             for (int32_t k = 0; k < 2; ++k) {
-                rotationIndices.push_back(numRepeats - k * nCols);
+                rotationIndices.push_back(repeats - k * nCols);
             }
             break;
 
         case LinTransType::PSI:
             // Generate a single index based on offset
-            rotationIndices.push_back(nCols * numRepeats);
+            rotationIndices.reserve(2);
+            rotationIndices.push_back(nCols * repeats);
+            if (repeats != 0) {
+                rotationIndices.push_back(nCols * repeats - blockSize);
+            }
             break;
 
         case LinTransType::TRANSPOSE:
             // Generate indices for transposing a square matrix via diagonals
-            rotationIndices.reserve(2*nCols);
+            rotationIndices.reserve(2 * nCols);
             for (int32_t k = -nCols + 1; k < nCols; ++k) {
                 rotationIndices.push_back((nCols - 1) * k);
             }
@@ -99,7 +119,6 @@ static std::vector<int32_t> GenLinTransIndices(uint32_t numCols, LinTransType ty
 
         default:
             OPENFHE_THROW("Linear transformation is undefined");
-            break;
     }
 
     return rotationIndices;
@@ -189,7 +208,7 @@ Ciphertext<DCRTPoly> EvalMultMatVec(std::shared_ptr<std::map<uint32_t,
                                     uint32_t numCols,
                                     ConstCiphertext<DCRTPoly>& ctVector,
                                     ConstCiphertext<DCRTPoly>& ctMatrix) {
-    if (numCols < 0) {
+    if (numCols <= 0) {
         OPENFHE_THROW("numCols must be positive");
     }
 
@@ -295,48 +314,180 @@ std::vector<double> EvalLinTransSigma(const std::vector<double>& vector, uint32_
  * @param numCols The number of columns in the transformation matrix.
  * @return The resulting ciphertext after the transformation.
 */
-Ciphertext<DCRTPoly> EvalLinTransTau(ConstCiphertext<DCRTPoly>& ctVector, uint32_t numCols) {
-    CryptoContext<DCRTPoly>  cc = ctVector->GetCryptoContext();
-    bool flag          = true;
-    Ciphertext<DCRTPoly> ctResult;
 
-    const size_t slots = cc->GetEncodingParams()->GetBatchSize();
+namespace {
 
-    for (size_t k = 0; k < numCols; ++k) {
-        size_t shift = (static_cast<size_t>(numCols) * k) % slots;
-        Ciphertext<DCRTPoly> ctRotated  = cc->EvalRotate(ctVector, shift);
-        Plaintext ptDiagonal = cc->MakeCKKSPackedPlaintext(GenTauDiag(slots, numCols, k));
-        Ciphertext<DCRTPoly> ctProd     = cc->EvalMult(ctRotated, ptDiagonal);
-
-        if (flag) {
-            ctResult = ctProd;
-            flag     = false;
-        }
-        else {
-            cc->EvalAddInPlace(ctResult, ctProd);
-        }
+void ValidateCompactSquareTransform(size_t slots, uint32_t numCols) {
+    if (numCols == 0) {
+        OPENFHE_THROW("numCols must be positive");
     }
-    return ctResult;
+
+    const size_t d = static_cast<size_t>(numCols);
+    const size_t blockSize = d * d;
+
+    if (slots < blockSize) {
+        OPENFHE_THROW("slots must be at least numCols * numCols");
+    }
 }
 
+std::vector<double> GenCompactRowShiftDiag(size_t slots, uint32_t numCols, uint32_t k, bool wrapPart) {
+    ValidateCompactSquareTransform(slots, numCols);
+
+    const size_t d = static_cast<size_t>(numCols);
+    const size_t kk = static_cast<size_t>(k);
+
+    if (kk >= d) {
+        OPENFHE_THROW("row-shift index k is out of range");
+    }
+
+    std::vector<double> diag(slots, 0.0);
+
+    for (size_t row = 0; row < d; ++row) {
+        const bool wraps = (row + kk >= d);
+        if (wraps != wrapPart) {
+            continue;
+        }
+
+        for (size_t col = 0; col < d; ++col) {
+            diag[row * d + col] = 1.0;
+        }
+    }
+
+    return diag;
+}
+
+std::vector<double> GenCompactTauDiag(size_t slots, uint32_t numCols, uint32_t col, bool wrapPart) {
+    ValidateCompactSquareTransform(slots, numCols);
+
+    const size_t d = static_cast<size_t>(numCols);
+    const size_t j = static_cast<size_t>(col);
+
+    if (j >= d) {
+        OPENFHE_THROW("Tau column index is out of range");
+    }
+
+    std::vector<double> diag(slots, 0.0);
+
+    for (size_t row = 0; row < d; ++row) {
+        const bool wraps = (row + j >= d);
+        if (wraps == wrapPart) {
+            diag[row * d + j] = 1.0;
+        }
+    }
+
+    return diag;
+}
+
+std::vector<double> EvalCompactRowShift(const std::vector<double>& vector, uint32_t numCols, uint32_t k) {
+    const size_t slots = vector.size();
+    ValidateCompactSquareTransform(slots, numCols);
+
+    const int32_t d = static_cast<int32_t>(numCols);
+    const int32_t kk = static_cast<int32_t>(k);
+    const int32_t blockSize = d * d;
+
+    std::vector<double> result(slots, 0.0);
+
+    auto addMaskedRotation = [&](int32_t shift, bool wrapPart) {
+        std::vector<double> diag = GenCompactRowShiftDiag(slots, numCols, k, wrapPart);
+        const int32_t signedSlots = static_cast<int32_t>(slots);
+        const int32_t normalizedShift = ((shift % signedSlots) + signedSlots) % signedSlots;
+
+        for (size_t i = 0; i < slots; ++i) {
+            result[i] += vector[(i + normalizedShift) % slots] * diag[i];
+        }
+    };
+
+    addMaskedRotation(d * kk, false);
+
+    if (kk != 0) {
+        addMaskedRotation(d * kk - blockSize, true);
+    }
+
+    return result;
+}
+
+}  // namespace
+
+Ciphertext<DCRTPoly> EvalLinTransTau(ConstCiphertext<DCRTPoly>& ctVector, uint32_t numCols) {
+    CryptoContext<DCRTPoly> cc = ctVector->GetCryptoContext();
+    const size_t slots = cc->GetEncodingParams()->GetBatchSize();
+
+    ValidateCompactSquareTransform(slots, numCols);
+
+    const int32_t nCols = static_cast<int32_t>(numCols);
+    const int32_t blockSize = nCols * nCols;
+
+    bool flag = true;
+    Ciphertext<DCRTPoly> ctResult;
+
+    for (uint32_t k = 0; k < numCols; ++k) {
+        const int32_t kk = static_cast<int32_t>(k);
+
+        Plaintext ptNoWrap = cc->MakeCKKSPackedPlaintext(
+            GenCompactTauDiag(slots, numCols, k, false)
+        );
+        Ciphertext<DCRTPoly> ctNoWrap = cc->EvalMult(
+            cc->EvalRotate(ctVector, nCols * kk),
+            ptNoWrap
+        );
+
+        if (flag) {
+            ctResult = ctNoWrap;
+            flag = false;
+        } else {
+            cc->EvalAddInPlace(ctResult, ctNoWrap);
+        }
+
+        if (k != 0) {
+            Plaintext ptWrap = cc->MakeCKKSPackedPlaintext(
+                GenCompactTauDiag(slots, numCols, k, true)
+            );
+            Ciphertext<DCRTPoly> ctWrap = cc->EvalMult(
+                cc->EvalRotate(ctVector, nCols * kk - blockSize),
+                ptWrap
+            );
+            cc->EvalAddInPlace(ctResult, ctWrap);
+        }
+    }
+
+    return ctResult;
+}
 
 /**
 * @brief LinTrans on a packed matrix
 */
 std::vector<double> EvalLinTransTau(const std::vector<double>& vector, uint32_t numCols) {
     const size_t slots = vector.size();
-    std::vector<double> result(slots, 0);
+    ValidateCompactSquareTransform(slots, numCols);
 
-    for (size_t k = 0; k < numCols; ++k) {
-        size_t shift = (numCols * k) % slots;
-        std::vector<double> diag = GenTauDiag(slots, numCols, k);
-        for (size_t i = 0; i < slots; ++i) {
-            result[i] += vector[(i + shift) % slots] * diag[i];
+    const int32_t nCols = static_cast<int32_t>(numCols);
+    const int32_t blockSize = nCols * nCols;
+
+    std::vector<double> result(slots, 0.0);
+
+    for (uint32_t k = 0; k < numCols; ++k) {
+        const int32_t kk = static_cast<int32_t>(k);
+
+        auto addMaskedRotation = [&](int32_t shift, bool wrapPart) {
+            std::vector<double> diag = GenCompactTauDiag(slots, numCols, k, wrapPart);
+            const int32_t signedSlots = static_cast<int32_t>(slots);
+            const int32_t normalizedShift = ((shift % signedSlots) + signedSlots) % signedSlots;
+
+            for (size_t i = 0; i < slots; ++i) {
+                result[i] += vector[(i + normalizedShift) % slots] * diag[i];
+            }
+        };
+
+        addMaskedRotation(nCols * kk, false);
+
+        if (k != 0) {
+            addMaskedRotation(nCols * kk - blockSize, true);
         }
     }
+
     return result;
 }
-
 Ciphertext<DCRTPoly> EvalLinTransTau(PrivateKey<DCRTPoly>& secretKey,
                                     ConstCiphertext<DCRTPoly>& ciphertext,
                                     uint32_t numCols) {
@@ -355,26 +506,40 @@ Ciphertext<DCRTPoly> EvalLinTransTau(PrivateKey<DCRTPoly>& secretKey,
 *
 * @param numCols   The number of padded cols in the encoded matrix
 */
-Ciphertext<DCRTPoly> EvalLinTransPhi(ConstCiphertext<DCRTPoly>& ctVector, uint32_t numCols, uint32_t numRepeats) {
+Ciphertext<DCRTPoly> EvalLinTransPhi(
+    ConstCiphertext<DCRTPoly>& ctVector,
+    uint32_t numCols,
+    uint32_t numRepeats
+) {
+    if (numCols == 0) {
+        OPENFHE_THROW("numCols must be positive");
+    }
 
-    CryptoContext<DCRTPoly>  cc = ctVector->GetCryptoContext();
+    CryptoContext<DCRTPoly> cc = ctVector->GetCryptoContext();
     const size_t slots = cc->GetEncodingParams()->GetBatchSize();
 
-    bool flag          = true;
+    const int32_t nCols = static_cast<int32_t>(numCols);
+    const int32_t repeats = static_cast<int32_t>(numRepeats);
+
+    bool flag = true;
     Ciphertext<DCRTPoly> ctResult;
 
-    for (size_t i = 0; i < 2; ++i) {
-        int32_t rotateIdx  = numRepeats - i * numCols;
+    for (int32_t i = 0; i < 2; ++i) {
+        const int32_t rotateIdx = repeats - i * nCols;
+
         Plaintext ptDiagonal = cc->MakeCKKSPackedPlaintext(
-                                    GenPhiDiag(slots, numCols, numRepeats, i));
-        Ciphertext<DCRTPoly> ctRotated  = cc->EvalRotate(ctVector, rotateIdx);
-        Ciphertext<DCRTPoly> ctProd  = cc->EvalMult(ctRotated, ptDiagonal);
+            GenPhiDiag(slots, numCols, repeats, i)
+        );
+
+        Ciphertext<DCRTPoly> ctRotated = cc->EvalRotate(ctVector, rotateIdx);
+        Ciphertext<DCRTPoly> ctProd = cc->EvalMult(ctRotated, ptDiagonal);
+
         if (flag) {
             ctResult = ctProd;
-            flag     = false;
-        }
-        else
+            flag = false;
+        } else {
             cc->EvalAddInPlace(ctResult, ctProd);
+        }
     }
 
     return ctResult;
@@ -423,14 +588,39 @@ Ciphertext<DCRTPoly> EvalLinTransPsi(PrivateKey<DCRTPoly>& secretKey,
 const std::vector<double> EvalLinTransPsi(const std::vector<double>& input,
                                            uint32_t numCols,
                                            uint32_t numRepeats) {
-    return RotateVector<std::vector<double>>(input, numCols * numRepeats);
+    return EvalCompactRowShift(input, numCols, numRepeats);
 }
-
 Ciphertext<DCRTPoly> EvalLinTransPsi(ConstCiphertext<DCRTPoly>& ctVector, uint32_t numCols, uint32_t numRepeats) {
     CryptoContext<DCRTPoly> cc = ctVector->GetCryptoContext();
-    return cc->EvalRotate(ctVector, numCols * numRepeats);
-}
+    const size_t slots = cc->GetEncodingParams()->GetBatchSize();
 
+    ValidateCompactSquareTransform(slots, numCols);
+
+    const int32_t nCols = static_cast<int32_t>(numCols);
+    const int32_t repeats = static_cast<int32_t>(numRepeats);
+    const int32_t blockSize = nCols * nCols;
+
+    Plaintext ptNoWrap = cc->MakeCKKSPackedPlaintext(
+        GenCompactRowShiftDiag(slots, numCols, numRepeats, false)
+    );
+    Ciphertext<DCRTPoly> ctResult = cc->EvalMult(
+        cc->EvalRotate(ctVector, nCols * repeats),
+        ptNoWrap
+    );
+
+    if (numRepeats != 0) {
+        Plaintext ptWrap = cc->MakeCKKSPackedPlaintext(
+            GenCompactRowShiftDiag(slots, numCols, numRepeats, true)
+        );
+        Ciphertext<DCRTPoly> ctWrap = cc->EvalMult(
+            cc->EvalRotate(ctVector, nCols * repeats - blockSize),
+            ptWrap
+        );
+        cc->EvalAddInPlace(ctResult, ctWrap);
+    }
+
+    return ctResult;
+}
 /**
  * @brief Multiplies two square matrices: CT x CT.
  * Implementation is based on https://eprint.iacr.org/2018/1041)
@@ -549,7 +739,7 @@ Ciphertext<DCRTPoly> EvalTranspose(PrivateKey<DCRTPoly>& secretKey,
 }
 Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext, uint32_t numCols) {
     try {
-        if (numCols < 0) {
+        if (numCols <= 0) {
             OPENFHE_THROW("numCols must be positive");
         }
         CryptoContext<DCRTPoly>  cc = ciphertext->GetCryptoContext();
@@ -559,7 +749,7 @@ Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext, uint32
         const int32_t nCols = static_cast<int32_t>(numCols);
 
         for (int32_t index = -nCols + 1; index < nCols; ++index) {
-            int32_t rotationIndex = (numCols - 1) * index;
+            int32_t rotationIndex = (nCols - 1) * index;
             auto diagonalVector   = GenTransposeDiag(slots, numCols, index);
             auto ptDiagonal       = cc->MakeCKKSPackedPlaintext(diagonalVector);
             auto ctRotated        = cc->EvalRotate(ciphertext, rotationIndex);

--- a/openfhe_numpy/cpp/lib/numpy_helper_functions.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_helper_functions.cpp
@@ -85,7 +85,8 @@ std::vector<double> MulMatVec(std::vector<std::vector<double>> mat, std::vector<
     if (m != k)
         OPENFHE_THROW("Mismatched vector sizes");
 
-    std::vector<double> result(m, 0);
+    std::vector<double> result(n, 0.0);
+
     for (uint32_t i = 0; i < n; i++) {
         for (uint32_t j = 0; j < m; j++) {
             result[i] += mat[i][j] * vec[j];

--- a/openfhe_numpy/cpp/lib/numpy_utils.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_utils.cpp
@@ -48,27 +48,39 @@ Compute diagonals for the permutation matrix Sigma.
 B[i,j] = A[i, i +j]
 */
 std::vector<double> GenSigmaDiag(size_t slots, size_t numCols, int32_t k) {
-    // the cast below is necessary as we don't want to mix signed and unsigned integers in calculations
-    int32_t nCols = static_cast<int32_t>(numCols);
-    int32_t n = nCols * nCols;
-    std::vector<double> diag(slots, 0);
+    if (numCols == 0) {
+        OPENFHE_THROW("numCols must be positive");
+    }
 
-    if (k >= 0) {
-        for (int32_t i = 0; i < n; i++) {
-            int32_t tmp = i - nCols * k;
-            if ((0 <= tmp) && (tmp < nCols - k)) {
-                diag[i] = 1;
+    const int32_t d = static_cast<int32_t>(numCols);
+    const size_t n = numCols * numCols;
+
+    if (slots < n || slots % n != 0) {
+        OPENFHE_THROW("slots must be a multiple of numCols * numCols");
+    }
+
+    std::vector<double> diag(slots, 0.0);
+
+    for (size_t t = 0; t < slots / n; ++t) {
+        const size_t base = t * n;
+
+        if (k >= 0) {
+            for (int32_t i = 0; i < static_cast<int32_t>(n); ++i) {
+                int32_t tmp = i - d * k;
+                if ((0 <= tmp) && (tmp < d - k)) {
+                    diag[base + i] = 1.0;
+                }
+            }
+        } else {
+            for (int32_t i = 0; i < static_cast<int32_t>(n); ++i) {
+                int32_t tmp = i - (d + k) * d;
+                if ((-k <= tmp) && (tmp < d)) {
+                    diag[base + i] = 1.0;
+                }
             }
         }
     }
-    else {
-        for (int32_t i = 0; i < n; i++) {
-            int32_t tmp = i - (nCols + k) * nCols;
-            if ((-k <= tmp) && (tmp < nCols)) {
-                diag[i] = 1;
-            }
-        }
-    }
+
     return diag;
 }
 
@@ -79,14 +91,29 @@ u_[d.k][k + d*i] = 1 for all 0 <= i < d
 */
 
 std::vector<double> GenTauDiag(size_t totalSlots, size_t numCols, int32_t k) {
-    uint32_t n = numCols * numCols;
-    std::vector<double> diag(totalSlots, 0);
+    if (numCols == 0) {
+        OPENFHE_THROW("numCols must be positive");
+    }
 
-    for (uint32_t t = 0; t < totalSlots / n; t++) {
-        for (uint32_t i = 0; i < numCols; i++) {
-            diag[(t * n) + k + numCols * i] = 1;
+    const size_t n = numCols * numCols;
+
+    if (totalSlots < n || totalSlots % n != 0) {
+        OPENFHE_THROW("slots must be a multiple of numCols * numCols");
+    }
+
+    if (k < 0 || static_cast<size_t>(k) >= numCols) {
+        OPENFHE_THROW("Tau diagonal index k is out of range");
+    }
+
+    std::vector<double> diag(totalSlots, 0.0);
+
+    for (size_t t = 0; t < totalSlots / n; ++t) {
+        const size_t base = t * n;
+        for (size_t i = 0; i < numCols; ++i) {
+            diag[base + static_cast<size_t>(k) + numCols * i] = 1.0;
         }
     }
+
     return diag;
 }
 
@@ -98,19 +125,35 @@ std::vector<double> GenTauDiag(size_t totalSlots, size_t numCols, int32_t k) {
  *diagonal
  */
 std::vector<double> GenPhiDiag(size_t slots, size_t numCols, int32_t k, int type) {
-    uint32_t n = numCols * numCols;
-    std::vector<double> diag(slots, 0);
-
-    if (type == 0) {
-        for (uint32_t i = 0; i < n; i++)
-            if ((i % numCols >= 0) && ((i % numCols) < numCols - k))
-                diag[i] = 1;
+    if (numCols == 0) {
+        OPENFHE_THROW("numCols must be positive");
     }
-    else {
-        for (uint32_t i = 0; i < n; i++)
-            if ((i % numCols >= numCols - k) && (i % numCols < numCols)) {
-                diag[i] = 1;
+
+    const size_t d = numCols;
+    const size_t n = d * d;
+
+    if (slots < n || slots % n != 0) {
+        OPENFHE_THROW("slots must be a multiple of numCols * numCols");
+    }
+
+    std::vector<double> diag(slots, 0.0);
+
+    for (size_t t = 0; t < slots / n; ++t) {
+        const size_t base = t * n;
+
+        if (type == 0) {
+            for (size_t i = 0; i < n; ++i) {
+                if ((i % d) < d - static_cast<size_t>(k)) {
+                    diag[base + i] = 1.0;
+                }
             }
+        } else {
+            for (size_t i = 0; i < n; ++i) {
+                if ((i % d) >= d - static_cast<size_t>(k)) {
+                    diag[base + i] = 1.0;
+                }
+            }
+        }
     }
 
     return diag;

--- a/openfhe_numpy/operations/__init__.py
+++ b/openfhe_numpy/operations/__init__.py
@@ -36,7 +36,6 @@ for working with homomorphically encrypted matrix/vector using OpenFHE.
 """
 
 from .broadcast import broadcast_to, generate_broadcast_key
-from . import matrix_arithmetic
 
 # Import arithmetic operations
 from .matrix_api import (
@@ -46,13 +45,16 @@ from .matrix_api import (
     dot,
     matmul,
     transpose,
-    pow,
-    cumulative_sum,
+    power,
+    cumsum,
     cumulative_reduce,
     sum,
     roll,
     mean,
 )
+
+from . import matrix_arithmetic
+from . import block_arithmetic
 
 # Import crypto context utilities
 from .crypto_helper import (
@@ -66,7 +68,10 @@ from .crypto_helper import (
     gen_accumulate_rows_key,
     gen_accumulate_cols_key,
     generate_slicing_key,
+    attach_block_matvec_keys,
+    attach_matvec_keys,
 )
+
 
 # Define public API
 __all__ = [
@@ -77,8 +82,8 @@ __all__ = [
     "dot",
     "matmul",
     "transpose",
-    "pow",
-    "cumulative_sum",
+    "power",
+    "cumsum",
     "cumulative_reduce",
     "sum",
     "roll",
@@ -97,4 +102,6 @@ __all__ = [
     "broadcast_to",
     "generate_broadcast_key",
     "generate_slicing_key",
+    "attach_matvec_keys",
+    "attach_block_matvec_keys",
 ]

--- a/openfhe_numpy/operations/arithmetic_utils.py
+++ b/openfhe_numpy/operations/arithmetic_utils.py
@@ -1,0 +1,143 @@
+# ==================================================================================
+#  BSD 2-Clause License
+#
+#  Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
+#
+#  All rights reserved.
+#
+#  Author TPOC: contact@openfhe.org
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice, this
+#     list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ==================================================================================
+
+"""
+Shared arithmetic helpers used by both plain (CTArray/PTArray) and block
+tensor operations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from openfhe_numpy.tensor.tensor import BaseTensor
+from openfhe_numpy.utils.errors import ONPIncompatibleShapeError, ONPValueError, ONPDimensionError
+from openfhe_numpy.utils.packing import _is_row_major, _is_col_major
+
+
+# ------------------------------------------------------------------------------
+# Arithmetic: Convention
+# ------------------------------------------------------------------------------
+def _require(condition: bool, left: Any, right: Any, message: str) -> None:
+    """Raise a shape error when ``condition`` is false."""
+    if not condition:
+        raise ONPIncompatibleShapeError(left, right, message)
+
+
+def _result_cls(a: BaseTensor, b: BaseTensor | None = None) -> BaseTensor:
+    """Return the encrypted tensor class if either operand is encrypted."""
+    if a.is_encrypted:
+        return type(a)
+
+    if b is not None and b.is_encrypted:
+        return type(b)
+
+    raise ONPValueError("Expected at least one encrypted tensor operand.")
+
+
+# ------------------------------------------------------------------------------
+# Arithmetic: Validation
+# ------------------------------------------------------------------------------
+
+
+def _assert_matvec_order(matrix_order: Any, vector_order: Any) -> bool:
+    """Return True for supported matrix-vector packing pairs."""
+    return (_is_row_major(matrix_order) and _is_col_major(vector_order)) or (
+        _is_col_major(matrix_order) and _is_row_major(vector_order)
+    )
+
+
+def _get_matvec_key_name(matrix_order: Any) -> str:
+    """Return the key name required by matrix-vector multiplication."""
+    if _is_row_major(matrix_order):
+        return "colkey"
+
+    if _is_col_major(matrix_order):
+        return "rowkey"
+
+    raise ONPValueError(f"Unsupported packing order: {matrix_order}")
+
+
+# ------------------------------------------------------------------------------
+# Arithmetic: Numpy axis convention
+# ------------------------------------------------------------------------------
+
+
+def _normalize_axis(axis, ndim: int) -> int:
+    """Normalize an integer axis.
+
+    Negative axes are converted to their positive equivalents.
+
+    Examples
+    --------
+    ndim=2:
+    - axis=0  -> 0
+    - axis=1  -> 1
+    - axis=-1 -> 1
+    - axis=-2 -> 0
+
+    Remark: Tuple axes are not supported
+    """
+    if not isinstance(axis, int):
+        raise ONPDimensionError(f"axis must be an integer, got {type(axis).__name__}.")
+
+    if axis < 0:
+        axis += ndim
+
+    if axis < 0 or axis >= ndim:
+        raise ONPDimensionError(f"axis {axis} is out of bounds for tensor with {ndim} dimensions.")
+
+    return axis
+
+
+def _normalize_sum_axis(axis, ndim: int) -> int | None:
+    """Normalize a NumPy-style reduction axis.
+
+    Unlike _normalize_axis, this helper allows axis=None.
+
+    - axis=None means reduce over all entries.
+    - negative axes are converted to positive axes.
+
+    Remark: Tuple axes are not supported
+    """
+    if axis is None:
+        return None
+
+    if not isinstance(axis, int):
+        raise ONPDimensionError(f"axis must be an integer or None, got {type(axis).__name__}.")
+
+    if axis < 0:
+        axis += ndim
+
+    if axis < 0 or axis >= ndim:
+        raise ONPDimensionError(f"axis {axis} is out of bounds for tensor with {ndim} dimensions.")
+
+    return axis

--- a/openfhe_numpy/operations/block_arithmetic.py
+++ b/openfhe_numpy/operations/block_arithmetic.py
@@ -1,0 +1,435 @@
+# ==================================================================================
+#  BSD 2-Clause License
+#
+#  Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
+#
+#  All rights reserved.
+#
+#  Author TPOC: contact@openfhe.org
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice, this
+#     list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ==================================================================================
+
+"""
+block_arithmetic.py
+
+This module implements block tensor arithmetic operations for encrypted tensors.
+Block operations are registered through the tensor dispatch system and usually
+delegate per-block work to CTArray operations.
+"""
+
+# Standard library imports
+from typing import Optional
+
+# Third-party imports
+from ..tensor.block_ctarray import BlockCTArray
+from .dispatch import register_tensor_function
+
+from ..utils.errors import (
+    ONPIncompatibleShapeError,
+    ONPNotImplementedError,
+    ONPValueError,
+    ONPDimensionError,
+)
+from .block_arithmetic_utils import (
+    _eval_block_binary,
+    _eval_block_scalar,
+    _eval_scalar_block,
+    _eval_block_dot,
+    _eval_block_matmul,
+)
+from .matrix_arithmetic import (
+    _pow,
+    _reduce_ct,
+    sum_ct,
+)
+from .arithmetic_utils import _normalize_axis, _normalize_sum_axis
+
+# ==============================================================================
+# Basic block arithmetic operations
+# ==============================================================================
+
+
+# ------------------------------------------------------------------------------
+# Addition Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "add", [("BlockCTArray", "BlockCTArray"), ("BlockCTArray", "BlockPTArray")]
+)
+def add_block_ct(a, b):
+    """Add two block tensors."""
+    return _eval_block_binary(a, b, "add")
+
+
+@register_tensor_function("add", [("BlockCTArray", "scalar")])
+def add_block_ct_scalar(a, scalar):
+    """Add a scalar to a block ciphertext tensor."""
+    return _eval_block_scalar(a, scalar, "add")
+
+
+# ------------------------------------------------------------------------------
+# Subtraction Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "subtract",
+    [
+        ("BlockCTArray", "BlockCTArray"),
+        ("BlockCTArray", "BlockPTArray"),
+        ("BlockPTArray", "BlockCTArray"),
+    ],
+)
+def subtract_block_ct(a, b):
+    """Subtract two block tensors."""
+    return _eval_block_binary(a, b, "subtract")
+
+
+@register_tensor_function("subtract", [("BlockCTArray", "scalar")])
+def subtract_block_ct_scalar(a, scalar):
+    """Subtract a scalar from a block ciphertext tensor."""
+    return _eval_block_scalar(a, scalar, "subtract")
+
+
+@register_tensor_function("subtract", [("scalar", "BlockCTArray")])
+def subtract_scalar_block_ct(scalar, a):
+    """Subtract a block ciphertext tensor from a scalar."""
+    return _eval_scalar_block(scalar, a, "subtract")
+
+
+# ------------------------------------------------------------------------------
+# Multiplication Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "multiply", [("BlockCTArray", "BlockCTArray"), ("BlockCTArray", "BlockPTArray")]
+)
+def multiply_block_ct(a, b):
+    """Multiply two block tensors element-wise."""
+    return _eval_block_binary(a, b, "multiply")
+
+
+@register_tensor_function("multiply", [("BlockCTArray", "scalar")])
+def multiply_block_ct_scalar(a, scalar):
+    """Multiply a block tensor by a scalar."""
+    return _eval_block_scalar(a, scalar, "multiply")
+
+
+# ==============================================================================
+# Linear Algebra Operations
+# ==============================================================================
+
+
+# ------------------------------------------------------------------------------
+# Matrix Multiplication Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "matmul",
+    [
+        ("BlockCTArray", "BlockCTArray"),
+        ("BlockCTArray", "BlockPTArray"),
+        ("BlockPTArray", "BlockCTArray"),
+    ],
+)
+def matmul_block_ct(a, b):
+    """Perform block vector dot or block matrix multiplication."""
+    return _eval_block_matmul(a, b)
+
+
+# ------------------------------------------------------------------------------
+# Dot Product Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function("dot", [("BlockCTArray", "BlockCTArray")])
+def dot_block_ct(a, b):
+    """Compute dot product of two block vectors."""
+    return _eval_block_dot(a, b)
+
+
+# ------------------------------------------------------------------------------
+# Transpose Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function("transpose", [("BlockCTArray",)])
+def transpose_block_ct(a):
+    """Transpose a block ciphertext tensor."""
+    if a.ndim == 1:
+        return a
+
+    if a.ndim != 2:
+        raise ONPDimensionError(f"transpose requires 1D or 2D tensor, got {a.ndim}D.")
+
+    grid_rows, grid_cols = a.grid_shape
+    blocks = []
+    for j in range(grid_cols):
+        for i in range(grid_rows):
+            blocks.append(a.get_block(i, j).transpose())
+
+    return type(a)(
+        data=blocks,
+        grid_shape=(grid_cols, grid_rows),
+        block_shape=(a.block_shape[1], a.block_shape[0]),
+        original_shape=(a.original_shape[1], a.original_shape[0]),
+        batch_size=a.batch_size,
+        order=a.order,
+    )
+
+
+# ==============================================================================
+# Advanced block operations
+# ==============================================================================
+
+
+# ------------------------------------------------------------------------------
+# Power Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function("power", [("BlockCTArray", "int")])
+def power_block_ct(a, exp):
+    """Raise a block ciphertext matrix to a nonnegative integer power."""
+    if a.ndim != 2:
+        raise ONPNotImplementedError("Block tensor power currently supports only block matrices.")
+
+    if a.original_shape[0] != a.original_shape[1]:
+        raise ONPIncompatibleShapeError(
+            a.original_shape,
+            a.original_shape,
+            "Block matrix power requires a square logical shape.",
+        )
+
+    if a.grid_shape[0] != a.grid_shape[1]:
+        raise ONPIncompatibleShapeError(
+            a.grid_shape,
+            a.grid_shape,
+            "Block matrix power requires a square block grid.",
+        )
+
+    return _pow(a, exp)
+
+
+# ------------------------------------------------------------------------------
+# Cumulative Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "cumsum",
+    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+)
+def cumsum_block_ct(obj, axis=None, keepdims=False):
+    """Compute cumulative sums for encrypted block tensors.
+
+    Currently supports:
+    - 1D block tensors across multiple blocks.
+    - 2D block tensors only when the cumulative axis stays inside each block.
+    """
+    if keepdims:
+        raise ONPNotImplementedError("Block cumsum does not support keepdims=True yet.")
+
+    if obj.ndim == 1:
+        if axis is None:
+            axis = 0
+
+        axis = _normalize_axis(axis, obj.ndim)
+
+        blocks = []
+        offset = None
+
+        for block in obj.data:
+            cumulative = block.cumsum(axis=0)
+
+            if offset is not None:
+                cumulative = cumulative + offset
+
+            blocks.append(cumulative)
+
+            block_sum = block.sum()
+            offset = block_sum if offset is None else offset + block_sum
+
+        return obj.clone(data=blocks)
+
+    if obj.ndim == 2:
+        if axis is None:
+            raise ONPNotImplementedError("Block cumsum(axis=None) is not implemented yet.")
+
+        axis = _normalize_axis(axis, obj.ndim)
+
+        if axis == 0 and obj.grid_shape[0] != 1:
+            raise ONPNotImplementedError(
+                "Block cumsum(axis=0) across multiple block rows is not implemented yet."
+            )
+
+        if axis == 1 and obj.grid_shape[1] != 1:
+            raise ONPNotImplementedError(
+                "Block cumsum(axis=1) across multiple block columns is not implemented yet."
+            )
+
+        return obj.clone(data=[block.cumsum(axis=axis) for block in obj.data])
+
+    raise ONPDimensionError(f"cumsum requires 1D or 2D tensor, got {obj.ndim}D.")
+
+
+@register_tensor_function(
+    "cumulative_reduce",
+    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+)
+def cumulative_reduce_block_ct(a, axis=0, keepdims=False):
+    """Compute cumulative reductions inside each encrypted block."""
+    if keepdims:
+        raise ONPNotImplementedError("Block cumulative_reduce does not support keepdims=True yet.")
+
+    if a.ndim != 2:
+        raise ONPDimensionError(f"cumulative_reduce requires a 2D block tensor, got {a.ndim}D.")
+
+    axis = _normalize_axis(axis, a.ndim)
+
+    if axis == 0 and a.grid_shape[0] != 1:
+        raise ONPNotImplementedError(
+            "Block cumulative_reduce(axis=0) across multiple block rows is not implemented yet."
+        )
+
+    if axis == 1 and a.grid_shape[1] != 1:
+        raise ONPNotImplementedError(
+            "Block cumulative_reduce(axis=1) across multiple block columns is not implemented yet."
+        )
+
+    return a.clone(data=[_reduce_ct(block, axis, keepdims) for block in a.data])
+
+
+# ------------------------------------------------------------------------------
+# Sum Operations
+# ------------------------------------------------------------------------------
+def _sum_ct_scalars(values):
+    """Add scalar CTArray values into one scalar CTArray."""
+    if not values:
+        raise ONPValueError("Cannot sum an empty block tensor.")
+
+    result = values[0]
+    for value in values[1:]:
+        result = result + value
+    return result
+
+
+@register_tensor_function(
+    "sum",
+    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+)
+def sum_block_ct(x: BlockCTArray, axis: Optional[int] = None, keepdims: bool = False):
+    """Sum encrypted block tensor elements."""
+    if keepdims:
+        raise ONPNotImplementedError("Block sum does not support keepdims=True yet.")
+
+    axis = _normalize_sum_axis(axis, x.ndim)
+
+    if x.ndim == 1:
+        return _sum_ct_scalars([sum_ct(block, None, False) for block in x.data])
+
+    if x.ndim != 2:
+        raise ONPDimensionError(f"sum requires 1D or 2D tensor, got {x.ndim}D.")
+
+    if axis is None:
+        return _sum_ct_scalars([sum_ct(block, None, False) for block in x.data])
+
+    if axis == 0:
+        grid_rows, grid_cols = x.grid_shape
+        blocks = []
+        for j in range(grid_cols):
+            col_sum = sum_ct(x.get_block(0, j), axis=0, keepdims=False)
+            for i in range(1, grid_rows):
+                col_sum = col_sum + sum_ct(x.get_block(i, j), axis=0, keepdims=False)
+            blocks.append(col_sum)
+
+        return type(x)(
+            data=blocks,
+            grid_shape=(grid_cols,),
+            block_shape=(x.block_shape[1],),
+            original_shape=(x.original_shape[1],),
+            batch_size=x.batch_size,
+            order=blocks[0].order,
+        )
+
+    if axis == 1:
+        grid_rows, grid_cols = x.grid_shape
+        blocks = []
+        for i in range(grid_rows):
+            row_sum = sum_ct(x.get_block(i, 0), axis=1, keepdims=False)
+            for j in range(1, grid_cols):
+                row_sum = row_sum + sum_ct(x.get_block(i, j), axis=1, keepdims=False)
+            blocks.append(row_sum)
+
+        return type(x)(
+            data=blocks,
+            grid_shape=(grid_rows,),
+            block_shape=(x.block_shape[0],),
+            original_shape=(x.original_shape[0],),
+            batch_size=x.batch_size,
+            order=blocks[0].order,
+        )
+
+    raise ONPValueError(f"Invalid axis {axis}.")
+
+
+# ------------------------------------------------------------------------------
+# Mean Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "mean",
+    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+)
+def mean_block_ct(x: BlockCTArray, axis: Optional[int] = None, keepdims: bool = False):
+    """Compute the arithmetic mean for encrypted block tensors.
+
+    - axis=None: mean over all entries.
+    - axis=0: mean down rows and return one value per column.
+    - axis=1: mean across columns and return one value per row.
+
+    Limitation:
+    - keepdims=True is not supported for block tensors yet.
+    """
+    if keepdims:
+        raise ONPNotImplementedError("Block mean does not support keepdims=True yet.")
+
+    axis = _normalize_sum_axis(axis, x.ndim)
+    mean_x = sum_block_ct(x, axis, keepdims=False)
+
+    if x.ndim == 1:
+        n = x.original_shape[0]
+
+    elif x.ndim == 2:
+        nrows, ncols = x.original_shape
+        if axis is None:
+            n = nrows * ncols
+        elif axis == 0:
+            n = nrows
+        elif axis == 1:
+            n = ncols
+        else:
+            raise ONPDimensionError(f"Invalid axis {axis} for 2D block tensor.")
+
+    else:
+        raise ONPDimensionError(f"mean requires 1D or 2D tensor, got {x.ndim}D.")
+
+    return mean_x * (1.0 / n)
+
+
+# ------------------------------------------------------------------------------
+# Rotation Operations
+# ------------------------------------------------------------------------------
+@register_tensor_function(
+    "roll",
+    [("BlockCTArray", "int"), ("BlockCTArray", "int", "int")],
+)
+def roll_block_ct(x: BlockCTArray, shift: int, axis: Optional[int] = None) -> BlockCTArray:
+    """Block tensor roll is not implemented yet."""
+    raise ONPNotImplementedError("Block roll is not implemented yet.")

--- a/openfhe_numpy/operations/block_arithmetic_utils.py
+++ b/openfhe_numpy/operations/block_arithmetic_utils.py
@@ -1,0 +1,375 @@
+# ==================================================================================
+#  BSD 2-Clause License
+#
+#  Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
+#
+#  All rights reserved.
+#
+#  Author TPOC: contact@openfhe.org
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice, this
+#     list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ==================================================================================
+
+from __future__ import annotations
+
+import operator
+from typing import Any, Callable
+
+from openfhe_numpy import ArrayEncodingType
+from openfhe_numpy.tensor.block_tensor import BlockFHETensor
+from openfhe_numpy.tensor.block_ctarray import BlockCTArray
+from openfhe_numpy.utils.errors import ONPNotImplementedError, ONPValueError
+from openfhe_numpy.utils.typecheck import Number
+from openfhe_numpy.utils.matlib import _sum_terms
+from openfhe_numpy.operations.arithmetic_utils import (
+    _result_cls,
+    _require,
+    _assert_matvec_order,
+    _get_matvec_key_name,
+)
+
+
+# ------------------------------------------------------------------------------
+# Type aliases
+# ------------------------------------------------------------------------------
+
+BlockOp = Callable[[Any, Any], Any]
+
+
+# ------------------------------------------------------------------------------
+# Supported element-wise operators
+# ------------------------------------------------------------------------------
+
+_OPS: dict[str, BlockOp] = {
+    "add": operator.add,
+    "subtract": operator.sub,
+    "multiply": operator.mul,
+}
+
+
+def _resolve_op(op_name: str) -> BlockOp:
+    """Return the blockwise Python operator for ``op_name``."""
+    try:
+        return _OPS[op_name]
+    except KeyError:
+        supported = ", ".join(sorted(_OPS))
+        raise ONPNotImplementedError(
+            f"Unsupported block operation {op_name!r}. Supported operations: {supported}."
+        ) from None
+
+
+# ------------------------------------------------------------------------------
+# Generic block helpers
+# ------------------------------------------------------------------------------
+
+
+def _build_block_result(
+    reference: BlockFHETensor,
+    blocks: list[Any],
+    *,
+    result_cls: type[BlockFHETensor] | None = None,
+    grid_shape: tuple[int, ...] | None = None,
+    block_shape: tuple[int, ...] | None = None,
+    original_shape: tuple[int, ...] | None = None,
+    order: Any | None = None,
+) -> BlockFHETensor:
+    """Construct a block tensor result while preserving reference metadata by default."""
+    cls = result_cls or type(reference)
+
+    return cls(
+        data=blocks,
+        grid_shape=grid_shape or reference.grid_shape,
+        block_shape=block_shape or reference.block_shape,
+        original_shape=original_shape or reference.original_shape,
+        batch_size=reference.batch_size,
+        order=reference.order if order is None else order,
+    )
+
+
+# ------------------------------------------------------------------------------
+# Element-wise operations
+# ------------------------------------------------------------------------------
+
+
+def _eval_block_binary(a: BlockFHETensor, b: BlockFHETensor, op_name: str) -> BlockFHETensor:
+    """Evaluate a blockwise binary operation on two block tensors."""
+
+    _require(
+        a.same_layout(b),
+        a.original_shape,
+        b.original_shape,
+        f"Block {op_name} requires identical block layout.",
+    )
+
+    op = _resolve_op(op_name)
+    blocks = [op(left, right) for left, right in zip(a.data, b.data)]
+
+    return _build_block_result(a, blocks, result_cls=BlockCTArray)
+
+
+def _eval_block_scalar(a: BlockFHETensor, scalar: Number, op_name: str) -> BlockFHETensor:
+    """Evaluate ``block_tensor op scalar`` blockwise."""
+    op = _resolve_op(op_name)
+    blocks = [op(block, scalar) for block in a.data]
+
+    return _build_block_result(a, blocks)
+
+
+def _eval_scalar_block(scalar: Number, a: BlockFHETensor, op_name: str) -> BlockFHETensor:
+    """Evaluate ``scalar op block_tensor`` blockwise."""
+    op = _resolve_op(op_name)
+    blocks = [op(scalar, block) for block in a.data]
+
+    return _build_block_result(a, blocks)
+
+
+# ------------------------------------------------------------------------------
+# Vector @ vector
+# ------------------------------------------------------------------------------
+
+
+def _eval_block_dot(a: BlockFHETensor, b: BlockFHETensor) -> Any:
+    """Compute a block-vector inner product."""
+
+    if not a.same_layout(b):
+        raise ONPValueError("Incompatible layout")
+
+    if not (a.is_encrypted or b.is_encrypted):
+        raise ONPNotImplementedError("Operation requires at least one encrypted operand.")
+
+    return _sum_terms(left @ right for left, right in zip(a.data, b.data))
+
+
+# ------------------------------------------------------------------------------
+# Matrix @ vector
+# ------------------------------------------------------------------------------
+
+
+def _assert_block_matvec_compatible(a: BlockFHETensor, b: BlockFHETensor) -> None:
+    """Validate block matrix-vector multiplication inputs."""
+    _require(
+        a.ndim == 2 and b.ndim == 1,
+        a.original_shape,
+        b.original_shape,
+        "Block matvec requires a 2-D block matrix and a 1-D block vector.",
+    )
+
+    if not (a.is_encrypted or b.is_encrypted):
+        raise ONPNotImplementedError("Operation requires at least one encrypted operand.")
+
+    _require(
+        a.original_shape[1] == b.original_shape[0],
+        a.original_shape,
+        b.original_shape,
+        "Block matvec dimension mismatch.",
+    )
+    _require(
+        a.grid_shape[1] == b.grid_shape[0],
+        a.grid_shape,
+        b.grid_shape,
+        "Block matvec requires matching inner block dimension.",
+    )
+    _require(
+        len(a.block_shape) == 2 and len(b.block_shape) == 1,
+        a.block_shape,
+        b.block_shape,
+        "Matrix blocks must be 2-D, vector blocks 1-D.",
+    )
+
+    _, block_cols = a.block_shape
+
+    _require(
+        b.block_shape == (block_cols,),
+        a.block_shape,
+        b.block_shape,
+        f"Vector block_shape must be ({block_cols},) to match matrix block_shape={a.block_shape}.",
+    )
+    _require(
+        a.batch_size == b.batch_size,
+        (a.batch_size,),
+        (b.batch_size,),
+        "Block matvec requires equal batch_size.",
+    )
+    _require(
+        _assert_matvec_order(a.order, b.order),
+        (a.order,),
+        (b.order,),
+        "Block matvec requires ROW_MAJOR matrix @ COL_MAJOR vector, or COL_MAJOR matrix @ ROW_MAJOR vector.",
+    )
+
+    key_name = _get_matvec_key_name(a.order)
+
+    for index in a.iter_block_indices():
+        block = a.get_block(*index)
+
+        if block.is_encrypted and key_name not in block.extra:
+            raise ONPValueError(
+                f"Matrix block {index} is missing extra[{key_name!r}]. "
+                "Call attach_matvec_keys(...) before block matrix-vector multiplication."
+            )
+
+
+def _eval_block_matvec(a: BlockFHETensor, b: BlockFHETensor) -> BlockFHETensor:
+    """Compute block matrix-vector multiplication.
+
+    For a block matrix A and block vector x, this computes y[i] = sum_k A[i,k] @ x[k].
+    """
+    _assert_block_matvec_compatible(a, b)
+
+    block_rows, _ = a.block_shape
+    grid_rows, grid_inner = a.grid_shape
+
+    blocks = [
+        _sum_terms(a.get_block(i, k) @ b.get_block(k) for k in range(grid_inner))
+        for i in range(grid_rows)
+    ]
+
+    return _build_block_result(
+        a,
+        blocks,
+        result_cls=BlockCTArray,
+        grid_shape=(grid_rows,),
+        block_shape=(block_rows,),
+        original_shape=(a.original_shape[0],),
+        order=a.order,
+    )
+
+
+# ------------------------------------------------------------------------------
+# Matrix @ matrix
+# ------------------------------------------------------------------------------
+
+
+def _assert_block_matmul_compatible(a: BlockFHETensor, b: BlockFHETensor) -> None:
+    """Validate block matrix-matrix multiplication inputs."""
+    _require(
+        a.ndim == 2 and b.ndim == 2,
+        a.original_shape,
+        b.original_shape,
+        "Block matmul requires two 2-D block matrices.",
+    )
+
+    if not (a.is_encrypted or b.is_encrypted):
+        raise ONPNotImplementedError("Operation requires at least one encrypted operand.")
+
+    _require(
+        a.original_shape[1] == b.original_shape[0],
+        a.original_shape,
+        b.original_shape,
+        "Block matmul dimension mismatch.",
+    )
+    _require(
+        a.grid_shape[1] == b.grid_shape[0],
+        a.grid_shape,
+        b.grid_shape,
+        "Block matmul requires matching inner block dimension.",
+    )
+    _require(
+        a.block_shape == b.block_shape,
+        a.block_shape,
+        b.block_shape,
+        "Block matmul requires equal block_shape.",
+    )
+    _require(
+        len(a.block_shape) == 2,
+        a.block_shape,
+        b.block_shape,
+        "Block matmul requires 2-D matrix blocks.",
+    )
+
+    block_rows, block_cols = a.block_shape
+
+    _require(
+        block_rows == block_cols,
+        a.block_shape,
+        b.block_shape,
+        "Block matmul requires square blocks.",
+    )
+    _require(
+        a.batch_size == b.batch_size,
+        (a.batch_size,),
+        (b.batch_size,),
+        "Block matmul requires equal batch_size.",
+    )
+    _require(
+        a.order == b.order == ArrayEncodingType.ROW_MAJOR,
+        (a.order,),
+        (b.order,),
+        "Block matmul currently requires both operands to use ROW_MAJOR packing.",
+    )
+
+
+def _eval_block_matmat(a: BlockFHETensor, b: BlockFHETensor) -> BlockFHETensor:
+    """Compute block matrix-matrix multiplication.
+
+    For block matrices A and B, this computes C[i,j] = sum_k A[i,k] @ B[k,j].
+
+    Required logical condition:
+    - a.shape = (m, k), b.shape = (k, n).
+
+    Current implementation limitations:
+    - Both tensors must be 2-D block matrices.
+    - Blocks must have the same square block_shape.
+    - Both operands must use ROW_MAJOR packing.
+    - At least one operand must be encrypted.
+
+    """
+    _assert_block_matmul_compatible(a, b)
+
+    grid_rows = a.grid_shape[0]
+    grid_inner = a.grid_shape[1]
+    grid_cols = b.grid_shape[1]
+
+    blocks = [
+        _sum_terms(a.get_block(i, k) @ b.get_block(k, j) for k in range(grid_inner))
+        for i in range(grid_rows)
+        for j in range(grid_cols)
+    ]
+
+    return _build_block_result(
+        a,
+        blocks,
+        result_cls=_result_cls(a, b),
+        grid_shape=(grid_rows, grid_cols),
+        block_shape=a.block_shape,
+        original_shape=(a.original_shape[0], b.original_shape[1]),
+        order=a.order,
+    )
+
+
+# ------------------------------------------------------------------------------
+# Matmul dispatch
+# ------------------------------------------------------------------------------
+
+
+def _eval_block_matmul(a: BlockFHETensor, b: BlockFHETensor) -> Any:
+    """Dispatch block matmul by operand ranks."""
+    if a.ndim == 1 and b.ndim == 1:
+        return _eval_block_dot(a, b)
+
+    if a.ndim == 2 and b.ndim == 1:
+        return _eval_block_matvec(a, b)
+
+    if a.ndim == 2 and b.ndim == 2:
+        return _eval_block_matmat(a, b)
+
+    raise ONPNotImplementedError(f"Block matmul does not support ndim={a.ndim} @ ndim={b.ndim}.")

--- a/openfhe_numpy/operations/crypto_helper.py
+++ b/openfhe_numpy/operations/crypto_helper.py
@@ -36,9 +36,11 @@ This module provides functions for generating rotation, accumulation, and other 
 keys needed for various homomorphic operations in OpenFHE-NumPy.
 """
 
+from typing import Any
 import openfhe
 import openfhe_numpy as backend  # Import from cpp source
-from openfhe_numpy.utils.matlib import next_power_of_two
+from ..utils.packing import _is_row_major, _is_col_major
+from ..utils.matlib import next_power_of_two
 
 
 def accumulation_depth(nrows: int, ncols: int, accumulate_by_rows: bool):
@@ -81,7 +83,7 @@ def sum_row_keys(secret_key: openfhe.PrivateKey, ncols: int = 0, slots: int = 0)
         Generated sum keys
     """
     context = secret_key.GetCryptoContext()
-    return context.EvalSumRowsKeyGen(secret_key, None, ncols, slots * 4)
+    return context.EvalSumRowsKeyGen(secret_key, None, ncols, 0)
 
 
 def sum_col_keys(secret_key: openfhe.PrivateKey, ncols: int = 0):
@@ -253,3 +255,72 @@ def generate_slicing_key(secret_key, original_shape):
     if indices:
         cc = secret_key.GetCryptoContext()
         cc.EvalRotateKeyGen(secret_key, sorted(indices))
+
+
+##############################################################################
+# BLOCK ARITHMETIC OPERATIONS
+##############################################################################
+
+
+# [CTArray] attach key for mat@vec product
+def attach_matvec_keys(matrix, secret_key, emit: bool = False) -> tuple[str, Any] | None:
+    """Attach the summation key required for matrix-vector multiplication.
+
+    Required keys:
+    - ROW_MAJOR matrix @ COL_MAJOR vector uses extra["colkey"].
+    - COL_MAJOR matrix @ ROW_MAJOR vector uses extra["rowkey"].
+
+    Limitation:
+    - The key is generated from one matrix layout. All blocks in a block matrix
+      are expected to share the same packing order and logical column count.
+    """
+    if matrix.ndim != 2:
+        raise ONPValueError("attach_matvec_keys expects a 2-D matrix.")
+
+    if _is_row_major(matrix.order):
+        key_name = "colkey"
+        key = sum_col_keys(secret_key)
+
+    elif _is_col_major(matrix.order):
+        key_name = "rowkey"
+        key = sum_row_keys(secret_key, matrix.ncols, matrix.batch_size)
+
+    else:
+        raise ONPValueError(f"Unsupported packing order: {matrix.order}")
+
+    matrix.extra[key_name] = key
+
+    if emit:
+        return key_name, key
+
+    return None
+
+
+# [BlockCTArray] attach key for mat@vec product
+def attach_block_matvec_keys(
+    block_matrix, secret_key, emit: bool = False
+) -> tuple[str, Any] | None:
+    """Attach summation keys to encrypted matrix blocks for block matvec.
+
+    Required keys:
+    - ROW_MAJOR matrix @ COL_MAJOR vector uses ``extra["colkey"]``.
+    - COL_MAJOR matrix @ ROW_MAJOR vector uses ``extra["rowkey"]``.
+
+    The key-generation parameters must match the CTArray evaluator:
+    - EvalSumCols(..., lhs.ncols, ...)
+    - EvalSumRows(..., lhs.nrows, ..., lhs.batch_size)
+    """
+
+    if block_matrix.ndim != 2 or len(block_matrix.data) <= 0:
+        raise ONPValueError("attach_matvec_keys expects a 2-D block matrix.")
+
+    reference = block_matrix.data[0]
+    key_name, key = attach_matvec_keys(reference, secret_key, True)
+
+    for block in block_matrix.data:
+        block.extra[key_name] = key
+
+    if emit:
+        return key_name, key
+
+    return None

--- a/openfhe_numpy/operations/matrix_api.py
+++ b/openfhe_numpy/operations/matrix_api.py
@@ -115,8 +115,8 @@ def multiply(a: ArrayLike, b: ArrayLike) -> ArrayLike:
     pass
 
 
-@tensor_function_api("pow", binary=True)
-def pow(a: ArrayLike, exponent: int) -> ArrayLike:
+@tensor_function_api("power", binary=True)
+def power(a: ArrayLike, exponent: int) -> ArrayLike:
     """
 
     For each element of the tensor, it raises that element to the given power.
@@ -256,8 +256,8 @@ def transpose(a: ArrayLike) -> ArrayLike:
 # ===========================
 
 
-@tensor_function_api("cumulative_sum", binary=False)
-def cumulative_sum(x: ArrayLike, /, *, axis: Optional[int] = None) -> ArrayLike:
+@tensor_function_api("cumsum", binary=False)
+def cumsum(x: ArrayLike, /, *, axis: Optional[int] = None) -> ArrayLike:
     """
         Compute the cumulative sum of tensor elements along a specified axis.\
         - For 1D inputs, axis must be None.
@@ -278,12 +278,12 @@ def cumulative_sum(x: ArrayLike, /, *, axis: Optional[int] = None) -> ArrayLike:
 
         See Also
         --------
-        numpy.cumulative_sum : Corresponding NumPy function.
+        numpy.cumsum : Corresponding NumPy function.
 
         Examples
         --------
         >>> import numpy as onp
-        >>> cumulative_sum(np.array([[1, 2], [3, 4]]), axis=1)
+        >>> cumsum(np.array([[1, 2], [3, 4]]), axis=1)
         array([[1, 3],
                [3, 7]])
     """
@@ -312,7 +312,7 @@ def cumulative_reduce(a: ArrayLike, axis: int = 0, keepdims: bool = False) -> Ar
 
     See Also
     --------
-    numpy.cumulative_sum : Similar operation for sum.
+    numpy.cumsum : Similar operation for sum.
 
     Examples
     --------
@@ -334,7 +334,7 @@ def sum(a: ArrayLike, /, *, axis: Optional[int] = None, keepdims: bool = False) 
     a : ArrayLike
         Input tensor.
     axis : int, optional
-        Axis along which to compute the sum. Default is 0.
+        Axis along which to compute the sum. Default is None.
         0: sum over rows
         1: sum over cols
     keepdims : bool, optional
@@ -384,7 +384,7 @@ def mean(
     a : ArrayLike
         Input tensor.
     axis : int, optional
-        Axis along which to compute the mean. Default is 0.
+        Axis along which to compute the mean. Default is Mean.
     keepdims : bool, optional
         If True, retains reduced dimensions. Default is False.
 
@@ -412,29 +412,30 @@ def mean(
 
 
 @tensor_function_api("roll", binary=False)
-def roll(a: ArrayLike, shift, axis: Optional[int] = None) -> ArrayLike:
+def roll(a: ArrayLike, shift: int, axis: Optional[int] = None) -> ArrayLike:
     """
-    Roll array elements along a given axis.
+    Roll packed vector elements.
 
     Elements that roll beyond the last position are re-introduced at the first.
+
+    Current limitation
+    ------------------
+    This function currently supports only packed vectors with ``axis=None``.
+    Matrix roll, tuple-axis roll, and block tensor roll are not implemented yet.
 
     Parameters
     ----------
     a : ArrayLike
-        Input array.
-    shift : int or tuple of ints
-        The number of places by which elements are shifted. If a tuple, then
-        axis must be a tuple of the same size, and each of the given axes is
-        shifted by the corresponding number. If an int while axis is a tuple
-        of ints, then the same value is used for all given axes.
-    axis : int or tuple of ints, optional
-        Axis or axes along which elements are shifted. By default, the array
-        is flattened before shifting, after which the original shape is restored.
+        Input packed vector.
+    shift : int
+        Number of positions by which elements are shifted.
+    axis : None, optional
+        Must be None in the current implementation.
 
     Returns
     -------
     res : ArrayLike
-        Output array, with the same shape as a.
+        Output vector with the same shape as ``a``.
 
     See Also
     --------
@@ -446,13 +447,18 @@ def roll(a: ArrayLike, shift, axis: Optional[int] = None) -> ArrayLike:
     >>> x = np.arange(10)
     >>> roll(x, 2)
     array([8, 9, 0, 1, 2, 3, 4, 5, 6, 7])
+    >>> roll(x, -2)
+    array([2, 3, 4, 5, 6, 7, 8, 9, 0, 1])
+    >>> roll(x, 0)
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    Unsupported examples
+    --------------------
     >>> x2 = np.reshape(x, (2, 5))
     >>> roll(x2, 1, axis=0)
-    array([[5, 6, 7, 8, 9],
-           [0, 1, 2, 3, 4]])
-    >>> roll(x2, (1, 1), axis=(1, 0))  # Multiple axes
-    array([[9, 5, 6, 7, 8],
-           [4, 0, 1, 2, 3]])
+    Traceback (most recent call last):
+        ...
+    ONPNotSupportedError: roll currently supports only packed vectors with axis=None.
     """
     pass
 

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -118,20 +118,6 @@ def add_scalar_cta(scalar, a):
     return CTArray(result, a.original_shape, a.batch_size, a.shape, a.order)
 
 
-@register_tensor_function(
-    "add", [("BlockCTArray", "BlockCTArray"), ("BlockCTArray", "BlockPTArray")]
-)
-def add_block_ct(a, b):
-    """Add two block tensors."""
-    raise NotImplementedError("BlockPTArray and BlockCTArray addition not implemented yet.")
-
-
-@register_tensor_function("add", [("BlockCTArray", "scalar")])
-def add_block_ct_scalar(a, scalar):
-    """Add a scalar to a block x."""
-    raise NotImplementedError("BlockPTArray and scalar addition not implemented yet.")
-
-
 # ------------------------------------------------------------------------------
 # Subtraction Operations
 # ------------------------------------------------------------------------------
@@ -237,21 +223,6 @@ def multiply_ct_scalar(a, scalar):
     return _eval_multiply(a, scalar)
 
 
-@register_tensor_function(
-    "multiply",
-    [("BlockCTArray", "BlockCTArray"), ("BlockCTArray", "BlockPTArray")],
-)
-def multiply_block_ct(a, b):
-    """Multiply two block tensors element-wise."""
-    raise NotImplementedError("BlockPTArray multiplication not implemented yet.")
-
-
-@register_tensor_function("multiply", [("BlockCTArray", "scalar")])
-def multiply_block_ct_scalar(a, scalar):
-    """Multiply a block tensor by a scalar."""
-    raise NotImplementedError("BlockPTArray and scalar multiplication not implemented yet.")
-
-
 ##############################################################################
 # MATRIX OPERATIONS
 ##############################################################################
@@ -266,8 +237,9 @@ def _eval_matvec_ct(lhs, rhs):
     if lhs.ndim == 2 and rhs.ndim == 1:
         if lhs.original_shape[1] != rhs.original_shape[0]:
             raise ONPIncompatibleShapeError(
-                lhs.original_shape, rhs.original_shape,
-                f"Matrix dimension [{lhs.original_shape}] mismatch with vector dimension [{rhs.shape}]"
+                lhs.original_shape,
+                rhs.original_shape,
+                f"Matrix dimension [{lhs.original_shape}] mismatch with vector dimension [{rhs.shape}]",
             )
 
         if lhs.order == ArrayEncodingType.ROW_MAJOR and rhs.order == ArrayEncodingType.COL_MAJOR:
@@ -283,7 +255,7 @@ def _eval_matvec_ct(lhs, rhs):
 
         elif lhs.order == ArrayEncodingType.COL_MAJOR and rhs.order == ArrayEncodingType.ROW_MAJOR:
             ct_mult = cc.EvalMult(lhs.data, rhs.data)
-            ct_prod = cc.EvalSumRows(ct_mult, lhs.nrows, lhs.extra["rowkey"], lhs.batch_size * 4)
+            ct_prod = cc.EvalSumRows(ct_mult, lhs.nrows, lhs.extra["rowkey"], 0)
             return CTArray(
                 ct_prod,
                 (lhs.original_shape[0],),
@@ -291,6 +263,7 @@ def _eval_matvec_ct(lhs, rhs):
                 (lhs.shape[1], lhs.shape[0]),
                 ArrayEncodingType.COL_MAJOR,
             )
+
         else:
             raise ONPError(
                 f"Encoding styles of matrix ({lhs.order}) and vector ({rhs.order}) must be complementary (ROW_MAJOR/COL_MAJOR or vice versa)."
@@ -403,33 +376,19 @@ def pow_ct(a, exp):
     return _pow(a, exp)
 
 
-@register_tensor_function("pow", [("BlockCTArray", "int")])
-def pow_block_ct(a, exp):
-    """Raise a block tensor to an integer power."""
-    raise NotImplementedError("BlockPTArray power not implemented yet.")
-
-
 # ------------------------------------------------------------------------------
 # Cumulative Sum Operations
 # ------------------------------------------------------------------------------
 
 
 @register_tensor_function(
-    "cumulative_sum",
+    "cumsum",
     [("CTArray",), ("CTArray", "int"), ("CTArray", "int", "bool")],
 )
-def cumulative_sum_ct(obj, axis=0, keepdims=True):
+def cumsum_ct(obj, axis=0, keepdims=True):
     """Compute cumulative sum of a tensor along specified axis."""
-    # return _cumulative_sum_ct(a, axis, keepdims)
-    return obj.cumulative_sum(axis)
-
-
-@register_tensor_function(
-    "cumulative_sum", [("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")]
-)
-def cumulative_sum_block_ct(obj, axis=0, keepdims=True):
-    """Compute cumulative sum of a block tensor along specified axis."""
-    raise NotImplementedError("BlockPTArray cumulative not implemented yet.")
+    # return _cumsum_ct(a, axis, keepdims)
+    return obj.cumsum(axis)
 
 
 # ------------------------------------------------------------------------------
@@ -467,12 +426,6 @@ def _reduce_ct(a, axis=0, keepdims=False):
 def cumulative_reduce_ct(a, axis=0, keepdims=False):
     """Compute cumulative reduction of a tensor along specified axis."""
     return _reduce_ct(a, axis, keepdims)
-
-
-@register_tensor_function("cumulative_reduce", [("BlockCTArray", "int")])
-def cumulative_reduce_block_ct(a, axis=0, keepdims=False):
-    """Compute cumulative reduction of a block tensor along specified axis."""
-    raise NotImplementedError("BlockPTArray power not implemented yet.")
 
 
 # ------------------------------------------------------------------------------
@@ -535,7 +488,9 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
     elif axis == 0:
         # Sum across each row of a packed_encoded matrix ciphertext: fhe_data
         if order == ArrayEncodingType.ROW_MAJOR:
-            ct_sum = cc.EvalSumRows(fhe_data, ncols, x.extra["rowkey"], x.batch_size * 4)
+            # subringDim=0 means "use the full cyclotomic order"; x.batch_size
+            # is not a reliable stand-in for it (see _eval_matvec_ct above).
+            ct_sum = cc.EvalSumRows(fhe_data, ncols, x.extra["rowkey"], 0)
             padded_shape = x.shape
             order = ArrayEncodingType.COL_MAJOR
         elif order == ArrayEncodingType.COL_MAJOR:
@@ -558,7 +513,9 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             padded_shape = x.shape
             order = ArrayEncodingType.ROW_MAJOR
         elif order == ArrayEncodingType.COL_MAJOR:
-            ct_sum = cc.EvalSumRows(fhe_data, nrows, x.extra["rowkey"], x.batch_size * 4)
+            # subringDim=0 means "use the full cyclotomic order"; x.batch_size
+            # is not a reliable stand-in for it (see _eval_matvec_ct above).
+            ct_sum = cc.EvalSumRows(fhe_data, nrows, x.extra["rowkey"], 0)
             padded_shape = (ncols, nrows)
             order = ArrayEncodingType.COL_MAJOR
         else:

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -47,8 +47,8 @@ from .dispatch import register_tensor_function
 
 from openfhe_numpy.tensor.ctarray import CTArray
 from openfhe_numpy.utils.errors import (
-    ONP_ERROR,
-    ONPIncompatibleShape,
+    ONPError,
+    ONPIncompatibleShapeError,
     ONPNotSupportedError,
     ONPValueError,
     ONPDimensionError,
@@ -265,7 +265,8 @@ def _eval_matvec_ct(lhs, rhs):
     cc = rhs.data.GetCryptoContext() if rhs.dtype == "CTArray" else lhs.data.GetCryptoContext()
     if lhs.ndim == 2 and rhs.ndim == 1:
         if lhs.original_shape[1] != rhs.original_shape[0]:
-            ONPIncompatibleShape(
+            raise ONPIncompatibleShapeError(
+                lhs.original_shape, rhs.original_shape,
                 f"Matrix dimension [{lhs.original_shape}] mismatch with vector dimension [{rhs.shape}]"
             )
 
@@ -291,13 +292,13 @@ def _eval_matvec_ct(lhs, rhs):
                 ArrayEncodingType.COL_MAJOR,
             )
         else:
-            ONP_ERROR(
+            raise ONPError(
                 f"Encoding styles of matrix ({lhs.order}) and vector ({rhs.order}) must be complementary (ROW_MAJOR/COL_MAJOR or vice versa)."
             )
     elif lhs.ndim == 1 and rhs.ndim == 1:
         return _dot(lhs, rhs)
     else:
-        ONPIncompatibleShape(lhs.original_shape, rhs.original_shape, "Matrix Product")
+        raise ONPIncompatibleShapeError(lhs.original_shape, rhs.original_shape, "Matrix Product")
 
 
 def _matmul_ct(lhs, rhs):
@@ -372,10 +373,10 @@ def transpose_ct(a):
 def _pow(x, exp: int):
     """Exponentiate a matrix to power k using homomorphic multiplication."""
     if not isinstance(exp, int):
-        ONP_ERROR(f"Exponent must be integer, got {type(exp).__name__}")
+        raise ONPError(f"Exponent must be integer, got {type(exp).__name__}")
 
     if exp < 0:
-        ONP_ERROR("Negative exponent not supported in homomorphic encryption")
+        raise ONPError("Negative exponent not supported in homomorphic encryption")
 
     if exp == 0:
         # return algebra.eye(tensor))
@@ -453,7 +454,7 @@ def _reduce_ct(a, axis=0, keepdims=False):
         A new tensor with cumulative reduction along the specified axis.
     """
     if axis not in (0, 1):
-        ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+        raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
     if axis == 0:
         ciphertext = EvalReduceCumRows(a.data, a.ncols, a.original_shape[1])
@@ -543,7 +544,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             order = ArrayEncodingType.ROW_MAJOR
 
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}] ")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}] ")
 
         if keepdims:
             shape = (cols, 1)
@@ -561,7 +562,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             padded_shape = (ncols, nrows)
             order = ArrayEncodingType.COL_MAJOR
         else:
-            ONPNotSupportedError(f"Not support the current encoding [{order}]")
+            raise ONPNotSupportedError(f"Not support the current encoding [{order}]")
 
         if keepdims:
             shape = (rows, 1)
@@ -569,7 +570,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             shape = (rows,)
 
     else:
-        ONPValueError(f"Invalid axis [{axis}]")
+        raise ONPValueError(f"Invalid axis [{axis}]")
 
     return CTArray(ct_sum, shape, x.batch_size, padded_shape, order)
 
@@ -580,7 +581,7 @@ def _ct_sum_vector(
 ):
     crypto_context = x.data.GetCryptoContext()
     if axis is not None:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
     ct_sum = crypto_context.EvalSum(x.data, x.shape[0])
     return CTArray(ct_sum, (), x.batch_size, x.shape, x.order)
 
@@ -592,7 +593,7 @@ def sum_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif x.ndim == 1:
         return _ct_sum_vector(x, axis)
     else:
-        ONPDimensionError(f"The dimension is invalid = {x.ndims}")
+        raise ONPDimensionError(f"The dimension is invalid = {x.ndims}")
 
 
 # ------------------------------------------------------------------------------
@@ -612,7 +613,7 @@ def mean_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
     elif axis == 1:  # sum over cols
         ct_mean = cc.EvalMult(sum_x.data, 1.0 / ncols)
     else:
-        ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
 
     return CTArray(
         ct_mean,
@@ -633,7 +634,7 @@ def roll(x: ArrayLike, shift: int, axis: Optional[int] = None) -> ArrayLike:
     if axis is None:
         return _ct_vector_rotation(x, -shift)
     else:
-        ONP_ERROR(f"This function only supports packed vector")
+        raise ONPError(f"This function only supports packed vector")
 
 
 def _ct_vector_rotation(ctv: CTArray, shift: int):

--- a/openfhe_numpy/tensor/__init__.py
+++ b/openfhe_numpy/tensor/__init__.py
@@ -6,6 +6,7 @@ from .ptarray import PTArray
 from .ctarray import CTArray
 from .block_tensor import BlockFHETensor
 from .block_ctarray import BlockCTArray
+from .block_ptarray import BlockPTArray
 
 
 # Import tensor constructors
@@ -19,8 +20,6 @@ __all__ = [
     "CTArray",
     "BlockFHETensor",
     "BlockCTArray",
+    "BlockPTArray",
     "array",
 ]
-
-
-# _register_all_operations()

--- a/openfhe_numpy/tensor/__init__.py
+++ b/openfhe_numpy/tensor/__init__.py
@@ -10,7 +10,7 @@ from .block_ptarray import BlockPTArray
 
 
 # Import tensor constructors
-from .constructors import array
+from .constructors import array, block_array
 
 # Define public API
 __all__ = [
@@ -22,4 +22,8 @@ __all__ = [
     "BlockCTArray",
     "BlockPTArray",
     "array",
+    "block_array",
 ]
+
+
+# _register_all_operations()

--- a/openfhe_numpy/tensor/block_ctarray.py
+++ b/openfhe_numpy/tensor/block_ctarray.py
@@ -102,3 +102,15 @@ class BlockCTArray(BlockFHETensor[Ciphertext]):
     def __neg__(self) -> BlockCTArray:
         """Return the blockwise homomorphic negation."""
         return self.clone(data=[-block for block in self.data])
+
+    def apply(self, func: Callable, *args: Any, **kwargs: Any) -> "BlockCTArray":
+        """Apply a ciphertext-level function to every encrypted block.
+
+        The function is applied to each block's underlying ciphertext while block
+        tensor metadata is preserved.
+        """
+        if not callable(func):
+            raise TypeError(f"apply expects a callable, got {type(func).__name__}.")
+
+        ct_result = [block.apply(func, *args, **kwargs) for block in self.data]
+        return self.clone(data=ct_result)

--- a/openfhe_numpy/tensor/block_ptarray.py
+++ b/openfhe_numpy/tensor/block_ptarray.py
@@ -29,54 +29,36 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
-
 from __future__ import annotations
-
 import numpy as np
-from openfhe import Ciphertext
 
-from ..utils.constants import UnpackType
+from openfhe import Plaintext
 from .block_tensor import BlockFHETensor
 
 
-class BlockCTArray(BlockFHETensor[Ciphertext]):
-    """Block tensor of encrypted blocks (CTArray).
+class BlockPTArray(BlockFHETensor[Plaintext]):
+    """Block tensor of plaintext blocks (PTArray).
 
-    This is a thin subclass. All storage, indexing, and metadata
-    logic lives in BlockFHETensor. BlockCTArray adds only:
-
-        - is_encrypted = True
-        - decrypt()
-        - higher tensor_priority for dispatch
+    All storage, indexing, and metadata logic lives in BlockFHETensor.
+    BlockPTArray adds plaintext decoding and a higher tensor priority than
+    PTArray for dispatch.
     """
 
-    tensor_priority = 40
-    is_encrypted = True
+    tensor_priority = 35
+    is_encrypted = False
 
-    def decrypt(
-        self,
-        secret_key,
-        unpack_type: UnpackType = UnpackType.ORIGINAL,
-        new_shape=None,
-    ) -> np.ndarray:
-        """Decrypt all blocks and return a NumPy array with original_shape."""
-        if isinstance(unpack_type, str):
-            unpack_type = UnpackType(unpack_type.lower())
+    def decrypt(self, *args, **kwargs) -> np.ndarray:
+        raise NotImplementedError(
+            "Decrypt is not defined for plaintext block arrays. Use decode()."
+        )
 
-        if unpack_type != UnpackType.ORIGINAL:
-            raise NotImplementedError(
-                "BlockCTArray.decrypt currently supports only unpack_type='original'."
-            )
+    def decode(self) -> np.ndarray:
+        """Decode all blocks and reassemble the original logical array.
 
+        Returns a NumPy array with shape == original_shape.
+        """
         if self.ndim == 1:
-            if new_shape is not None:
-                raise NotImplementedError("new_shape is not supported for 1-D BlockCTArray.")
-            chunks = [
-                np.asarray(block.decrypt(secret_key, unpack_type=unpack_type)).reshape(
-                    self.block_shape
-                )
-                for block in self.data
-            ]
+            chunks = [np.asarray(block.decode()).reshape(self.block_shape) for block in self.data]
             full = np.concatenate(chunks)
             return full[: self.original_shape[0]]
 
@@ -89,16 +71,9 @@ class BlockCTArray(BlockFHETensor[Ciphertext]):
         for gi in range(grid_rows):
             for gj in range(grid_cols):
                 block = self.get_block(gi, gj)
-                plain = np.asarray(block.decrypt(secret_key, unpack_type=unpack_type)).reshape(
-                    self.block_shape
-                )
-                r0, c0 = gi * br, gj * bc
+                plain = np.asarray(block.decode()).reshape(self.block_shape)
+                r0 = gi * br
+                c0 = gj * bc
                 full[r0 : r0 + br, c0 : c0 + bc] = plain
 
-        if new_shape is not None:
-            return full[:rows, :cols].reshape(new_shape)
         return full[:rows, :cols]
-
-    def __neg__(self) -> BlockCTArray:
-        """Return the blockwise homomorphic negation."""
-        return self.clone(data=[-block for block in self.data])

--- a/openfhe_numpy/tensor/block_tensor.py
+++ b/openfhe_numpy/tensor/block_tensor.py
@@ -29,31 +29,628 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
-from typing import Generic
+from __future__ import annotations
+
+from math import prod
+from typing import Any, Generic, TypeVar
+from operator import index as operator_index
+
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from .tensor import FHETensor, TPL
+from .tensor import BaseTensor
 
 
-class BlockFHETensor(FHETensor[TPL], Generic[TPL]):
-    """Base class for block tensor implementations"""
+TPL = TypeVar("TPL")
+
+# =============================================================================
+# Block tensor base class
+# =============================================================================
+
+
+class BlockFHETensor(BaseTensor, Generic[TPL]):
+    """Base class for block-encoded FHE tensors.
+
+    A block tensor stores a logical 1-D or 2-D tensor as a flat row-major list of
+    encoded blocks. Each block stores a local chunk of the tensor, and the block
+    grid describes how those chunks tile the padded logical shape.
+
+    Parameters
+    ----------
+    data : list[Any] | tuple[Any, ...]
+        Flat row-major sequence of encoded blocks. Nested block lists are not
+        accepted here;  construction should use ``block_array(...)``.
+    block_shape : tuple[int, ...]
+        Logical shape of each encoded block. Only 1-D and 2-D blocks are
+        currently supported.
+    original_shape : tuple[int, ...]
+        Shape requested by the user before block padding.
+    batch_size : int
+        Number of plaintext slots available to each encoded block.
+    order : ArrayEncodingType, default=ArrayEncodingType.ROW_MAJOR
+        Packing order used by the encoded blocks.
+    grid_shape : tuple[int, ...] | None, default=None
+        Shape of the block grid. For 1-D block tensors, this is inferred from
+        ``len(data)`` when omitted. For 2-D block tensors, it must be provided.
+
+    Notes
+    -----
+    The padded tensor shape is computed as ``grid_shape * block_shape`` elementwise.
+    Thus, mathematically, if ``grid_shape = g`` and ``block_shape = b``, then
+    ``shape[i] = g[i] * b[i]``. The original logical shape must fit inside this
+    padded shape.
+
+    Limitations
+    -----------
+    - Only 1-D vectors and 2-D matrices are supported.
+    - Logical slicing/rotation/broadcasting is not implemented yet.
+
+    Subclasses declare encryption status using the class attribute:
+    ``is_encrypted = True`` for ciphertext block arrays and ``False`` for
+    plaintext block arrays.
+    """
+
+    tensor_priority = 30
+    is_encrypted: bool = False
+    __hash__ = None
 
     def __init__(
         self,
-        blocks,
-        block_shape,
-        original_shape,
-        batch_size,
-        ncols=1,
-        order=ArrayEncodingType.ROW_MAJOR,
-    ):
-        self._blocks = blocks
+        data: list[Any] | tuple[Any, ...],
+        block_shape: tuple[int, ...],
+        original_shape: tuple[int, ...],
+        batch_size: int,
+        order: ArrayEncodingType = ArrayEncodingType.ROW_MAJOR,
+        grid_shape: tuple[int, ...] | None = None,
+    ) -> None:
+        """Initialize a low-level block tensor from flat block storage.
+        This constructor validates only structural metadata.
+        Raises
+        ------
+        ValueError
+            If the block list is empty, nested, dimensionally inconsistent, or
+            cannot fit ``original_shape`` into the padded block layout.
+        """
+        if not isinstance(data, (list, tuple)):
+            raise ValueError("BlockFHETensor data must be a flat list/tuple of blocks.")
+
+        data = list(data)
+
+        if len(data) == 0:
+            raise ValueError("Block storage cannot be empty.")
+
+        if any(isinstance(block, (list, tuple)) for block in data):
+            raise ValueError(
+                "BlockFHETensor expects flat row-major block data. "
+                "Use block_array(...) for nested/user-facing input."
+            )
+
+        block_shape = tuple(block_shape)
+        original_shape = tuple(original_shape)
+
+        if grid_shape is None:
+            if len(block_shape) == 1:
+                grid_shape = (len(data),)
+            else:
+                raise ValueError("grid_shape is required for matrix BlockFHETensor.")
+
+        grid_shape = tuple(grid_shape)
+
+        self._validate_metadata(
+            data=data,
+            block_shape=block_shape,
+            original_shape=original_shape,
+            batch_size=batch_size,
+            grid_shape=grid_shape,
+        )
+
+        padded_shape = tuple(
+            grid_dim * block_dim for grid_dim, block_dim in zip(grid_shape, block_shape)
+        )
+
+        self._data = data
+        self._original_shape = original_shape
+        self._batch_size = batch_size
+        self._shape = padded_shape
+        self._order = order
+        self._dtype = self.__class__.__name__
         self._block_shape = block_shape
-        super().__init__(None, original_shape, batch_size, ncols, order)
+        self._grid_shape = grid_shape
+
+    @staticmethod
+    def _validate_metadata(
+        data: list[Any],
+        block_shape: tuple[int, ...],
+        original_shape: tuple[int, ...],
+        batch_size: int,
+        grid_shape: tuple[int, ...],
+    ) -> None:
+        """Validate block-grid metadata.
+
+        Checks that ranks agree, dimensions are positive, each block fits in the
+        available slot capacity, the number of blocks matches ``grid_shape``, and
+        ``original_shape`` fits inside the padded shape.
+        """
+        if len(block_shape) not in (1, 2):
+            raise ValueError(f"Only 1D/2D block tensors are supported; got {block_shape}.")
+        if len(original_shape) not in (1, 2):
+            raise ValueError(f"Only 1D/2D tensors are supported; got {original_shape}.")
+        if len(block_shape) != len(original_shape):
+            raise ValueError(
+                f"block_shape rank must equal original_shape rank; "
+                f"got {block_shape} and {original_shape}."
+            )
+        if len(grid_shape) != len(block_shape):
+            raise ValueError(
+                f"grid_shape rank must equal block_shape rank; got {grid_shape} and {block_shape}."
+            )
+        if any(dim <= 0 for dim in block_shape):
+            raise ValueError(f"block_shape must be positive; got {block_shape}.")
+        if any(dim <= 0 for dim in original_shape):
+            raise ValueError(f"original_shape must be positive; got {original_shape}.")
+        if any(dim <= 0 for dim in grid_shape):
+            raise ValueError(f"grid_shape must be positive; got {grid_shape}.")
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive; got {batch_size}.")
+
+        block_slots = prod(block_shape)
+        if block_slots > batch_size:
+            raise ValueError(
+                f"block_shape={block_shape} requires {block_slots} slots, "
+                f"but batch_size={batch_size}."
+            )
+
+        expected_blocks = prod(grid_shape)
+        if len(data) != expected_blocks:
+            raise ValueError(
+                f"grid_shape={grid_shape} expects {expected_blocks} blocks, but got {len(data)}."
+            )
+
+        padded_shape = tuple(g * b for g, b in zip(grid_shape, block_shape))
+        if any(orig > pad for orig, pad in zip(original_shape, padded_shape)):
+            raise ValueError(
+                f"original_shape={original_shape} cannot exceed padded_shape={padded_shape}."
+            )
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
 
     @property
-    def blocks(self):
-        return self._blocks
+    def data(self) -> list[Any]:
+        """Flat row-major list of encoded blocks."""
+        return self._data
+
+    @data.setter
+    def data(self, value: Any) -> None:
+        """Replace the internal block list without revalidating metadata."""
+        self._data = value
 
     @property
-    def block_shape(self):
+    def original_shape(self) -> tuple[int, ...]:
+        """Logical tensor shape before block padding."""
+        return self._original_shape
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Padded logical shape covered by the block grid."""
+        return self._shape
+
+    @property
+    def batch_size(self) -> int:
+        """Number of plaintext slots available per encoded block."""
+        return self._batch_size
+
+    @property
+    def order(self) -> ArrayEncodingType:
+        """Packing order used by the encoded blocks."""
+        return self._order
+
+    @property
+    def dtype(self) -> str:
+        """Tensor dtype name, currently the concrete class name."""
+        return self._dtype
+
+    @property
+    def ndim(self) -> int:
+        """Number of logical tensor dimensions."""
+        return len(self._original_shape)
+
+    @property
+    def ncols(self) -> int | None:
+        """Number of padded columns for a matrix, or ``None`` for vectors."""
+        if self.ndim == 2:
+            return self._shape[1]
+        return None
+
+    @property
+    def block_shape(self) -> tuple[int, ...]:
+        """Logical shape of each encoded block."""
         return self._block_shape
+
+    @property
+    def grid_shape(self) -> tuple[int, ...]:
+        """Shape of the block grid."""
+        return self._grid_shape
+
+    @property
+    def block_ndim(self) -> int:
+        """Number of dimensions inside each block."""
+        return len(self._block_shape)
+
+    @property
+    def block_size(self) -> int:
+        """Number of logical entries represented by one block."""
+        return prod(self._block_shape)
+
+    @property
+    def num_blocks(self) -> int:
+        """Total number of encoded blocks."""
+        return len(self._data)
+
+    @property
+    def is_vector(self) -> bool:
+        """Whether this block tensor is logically 1-D."""
+        return self.ndim == 1
+
+    @property
+    def is_matrix(self) -> bool:
+        """Whether this block tensor is logically 2-D."""
+        return self.ndim == 2
+
+    @property
+    def logical_size(self) -> int:
+        """Number of entries in the unpadded logical tensor."""
+        return prod(self._original_shape)
+
+    @property
+    def padded_size(self) -> int:
+        """Number of entries in the padded logical tensor."""
+        return prod(self._shape)
+
+    @property
+    def total_slot_capacity(self) -> int:
+        """Total slot capacity across all blocks."""
+        return self.num_blocks * self._batch_size
+
+    @property
+    def slot_utilization(self) -> float:
+        """Fraction of total block slot capacity used by logical entries."""
+        return self.logical_size / self.total_slot_capacity
+
+    @property
+    def padding_overhead(self) -> float:
+        """Fraction of padded logical entries outside ``original_shape``."""
+        return 1.0 - (self.logical_size / self.padded_size)
+
+    @property
+    def info(self) -> dict[str, Any]:
+        """Return a dictionary of layout and storage metadata."""
+        return {
+            "dtype": self._dtype,
+            "original_shape": self._original_shape,
+            "shape": self._shape,
+            "block_shape": self._block_shape,
+            "grid_shape": self._grid_shape,
+            "num_blocks": self.num_blocks,
+            "block_size": self.block_size,
+            "batch_size": self._batch_size,
+            "logical_size": self.logical_size,
+            "padded_size": self.padded_size,
+            "total_slot_capacity": self.total_slot_capacity,
+            "slot_utilization": self.slot_utilization,
+            "padding_overhead": self.padding_overhead,
+            "order": self._order,
+            "encrypted": self.is_encrypted,
+        }
+
+    # ------------------------------------------------------------------
+    # Block-grid indexing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_index(index: int, size: int, name: str) -> int:
+        """Normalize a possibly negative Python index."""
+        try:
+            index = operator_index(index)
+        except TypeError as exc:
+            raise TypeError(f"{name} must be an integer; got {index!r}.") from exc
+
+        if index < 0:
+            index += size
+        if index < 0 or index >= size:
+            raise IndexError(f"{name} {index} out of range for size={size}.")
+        return index
+
+    def _block_offset(self, grid_index: tuple[int, ...]) -> int:
+        """Convert a block-grid index to a flat row-major block offset."""
+        if len(grid_index) != len(self._grid_shape):
+            raise IndexError(
+                f"Expected {len(self._grid_shape)} block index value(s), got {len(grid_index)}."
+            )
+
+        if len(self._grid_shape) == 1:
+            i = self._normalize_index(grid_index[0], self._grid_shape[0], "Block index")
+            return i
+
+        i, j = grid_index
+        rows, cols = self._grid_shape
+        i = self._normalize_index(i, rows, "Block row")
+        j = self._normalize_index(j, cols, "Block column")
+        return i * cols + j
+
+    def get_block(self, *grid_index) -> Any:
+        """Return a block by block-grid index.
+
+        The index may be passed either as separate integers, e.g.
+        ``get_block(i, j)``, or as one tuple, e.g. ``get_block((i, j))``.
+        """
+        if len(grid_index) == 1 and isinstance(grid_index[0], tuple):
+            grid_index = grid_index[0]
+        return self._data[self._block_offset(tuple(grid_index))]
+
+    def get_block_row(self, i: int) -> list[Any]:
+        """Return all blocks in block row ``i``."""
+        if self.ndim != 2:
+            raise ValueError("get_block_row is only valid for block matrices.")
+        rows, cols = self._grid_shape
+        i = self._normalize_index(i, rows, "Block row")
+        start = i * cols
+        return self._data[start : start + cols]
+
+    def get_block_col(self, j: int) -> list[Any]:
+        """Return all blocks in block column ``j``."""
+        if self.ndim != 2:
+            raise ValueError("get_block_col is only valid for block matrices.")
+        rows, cols = self._grid_shape
+        j = self._normalize_index(j, cols, "Block column")
+        return [self._data[i * cols + j] for i in range(rows)]
+
+    def iter_block_indices(self):
+        """Yield block-grid indices in row-major order."""
+        if self.ndim == 1:
+            for i in range(self._grid_shape[0]):
+                yield (i,)
+        else:
+            rows, cols = self._grid_shape
+            for i in range(rows):
+                for j in range(cols):
+                    yield (i, j)
+
+    def block_grid(self) -> list[Any]:
+        """Return a nested block view for debugging and inspection.
+
+        The returned containers are new Python lists, but block objects are not
+        copied.
+        """
+        if self.ndim == 1:
+            return list(self._data)
+        rows, cols = self._grid_shape
+        return [self._data[i * cols : (i + 1) * cols] for i in range(rows)]
+
+    # ------------------------------------------------------------------
+    # Logical indexing
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Return the length of the first logical dimension."""
+        return self._original_shape[0]
+
+    def __getitem__(self, key):
+        """Return a logical scalar entry by integer index.
+
+        Negative integer indices follow Python indexing convention.
+
+        Limitations
+        -----------
+        - Slice indexing is not implemented.
+        - Only scalar logical entries are supported.
+        - Actual extraction depends on whether the encoded block implements
+          ``__getitem__``.
+        """
+        if isinstance(key, slice) or (
+            isinstance(key, tuple) and any(isinstance(k, slice) for k in key)
+        ):
+            raise NotImplementedError(
+                "Logical slicing is not implemented yet. "
+                "Use get_block_row/get_block_col for block-level access."
+            )
+        return self._get_logical_entry(key)
+
+    def get_entry(self, *key):
+        """Return a logical scalar entry.
+
+        This is a convenience wrapper around ``__getitem__`` that accepts either
+        ``get_entry(i)`` for vectors or ``get_entry(i, j)`` for matrices.
+        """
+        if len(key) == 0:
+            raise IndexError("BlockFHETensor does not support scalar indexing.")
+        if len(key) == 1:
+            return self[key[0]]
+        return self[tuple(key)]
+
+    def _locate_index(self, key) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        """Map a logical index to ``(block_index, local_index)``."""
+        if self.ndim == 1:
+            if isinstance(key, tuple):
+                if len(key) != 1:
+                    raise IndexError(f"Expected one index for vector, got {key}.")
+                key = key[0]
+
+            i = self._normalize_index(key, self._original_shape[0], "Index")
+            b = self._block_shape[0]
+            return (i // b,), (i % b,)
+
+        if self.ndim == 2:
+            if not isinstance(key, tuple) or len(key) != 2:
+                raise IndexError(f"Expected two indices for matrix, got {key}.")
+
+            i, j = key
+            nrows, ncols = self._original_shape
+            i = self._normalize_index(i, nrows, "Row index")
+            j = self._normalize_index(j, ncols, "Column index")
+
+            br, bc = self._block_shape
+            return (i // br, j // bc), (i % br, j % bc)
+
+        raise ValueError(f"Unsupported ndim={self.ndim}.")
+
+    def _get_logical_entry(self, key):
+        """Extract a logical entry from the selected encoded block.
+
+        This helper performs index mapping only. The concrete block type is
+        responsible for supporting local ``__getitem__`` extraction.
+        """
+        block_index, local_index = self._locate_index(key)
+        block = self.get_block(*block_index)
+        if not hasattr(block, "__getitem__"):
+            raise NotImplementedError(
+                "Block object does not support __getitem__. "
+                f"block_type={type(block).__name__}, local_index={local_index}."
+            )
+        try:
+            return block[local_index]
+        except Exception as exc:
+            raise NotImplementedError(
+                "Logical entry extraction from an encoded block failed. "
+                f"Unsupported local_index={local_index}."
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Operator dispatch
+    # ------------------------------------------------------------------
+
+    def __add__(self, other):
+        """Return ``self + other`` through tensor dispatch."""
+        return self.__tensor_function__("add", (self, other))
+
+    def __radd__(self, other):
+        """Return ``other + self`` through tensor dispatch."""
+        return self.__tensor_function__("add", (other, self))
+
+    def __sub__(self, other):
+        """Return ``self - other`` through tensor dispatch."""
+        return self.__tensor_function__("subtract", (self, other))
+
+    def __rsub__(self, other):
+        """Return ``other - self`` through tensor dispatch."""
+        return self.__tensor_function__("subtract", (other, self))
+
+    def __mul__(self, other):
+        """Return element-wise ``self * other`` through tensor dispatch."""
+        return self.__tensor_function__("multiply", (self, other))
+
+    def __rmul__(self, other):
+        """Return element-wise ``other * self`` through tensor dispatch."""
+        return self.__tensor_function__("multiply", (other, self))
+
+    def __matmul__(self, other):
+        """Return ``self @ other`` through tensor dispatch."""
+        return self.__tensor_function__("matmul", (self, other))
+
+    def __pow__(self, exp):
+        """Return matrix power ``self ** exp`` through tensor dispatch."""
+        return self.__tensor_function__("pow", (self, exp))
+
+    @property
+    def T(self):
+        """Transpose view/result, equivalent to ``self.transpose()``."""
+        return self.transpose()
+
+    def sum(self, axis=None, keepdims: bool = False):
+        """Sum block tensor entries through tensor dispatch."""
+        return self.__tensor_function__("sum", (self,), {"axis": axis, "keepdims": keepdims})
+
+    def cumsum(self, axis=None, keepdims: bool = False):
+        """Compute cumulative sums through tensor dispatch."""
+        return self.__tensor_function__("cumsum", (self,), {"axis": axis, "keepdims": keepdims})
+
+    def transpose(self):
+        """Transpose the block tensor through tensor dispatch.
+
+        For 1-D tensors, this follows NumPy behavior and returns the tensor
+        unchanged.
+        """
+        return self.__tensor_function__("transpose", (self,))
+
+    def cumulative_reduce(self, axis: int = 0, keepdims: bool = False):
+        """Compute backend-specific cumulative reduction through dispatch.
+
+        This is an FHE-specific operation, not a direct NumPy API equivalent.
+        """
+        return self.__tensor_function__(
+            "cumulative_reduce", (self,), {"axis": axis, "keepdims": keepdims}
+        )
+
+    def __tensor_function__(self, func_name, args, kwargs=None, verbose: bool = False):
+        """Dispatch tensor operations via the registry."""
+        from openfhe_numpy.operations.dispatch import dispatch_tensor_function
+
+        return dispatch_tensor_function(func_name, args, kwargs or {}, verbose=verbose)
+
+    # ------------------------------------------------------------------
+    # Copy / equality / repr
+    # ------------------------------------------------------------------
+
+    def clone(self, data: list[Any] | None = None) -> BlockFHETensor:
+        """Return a shallow copy, optionally with new block data.
+
+        Metadata is preserved. Block objects are not deep-copied unless the
+        caller supplies already-copied block data.
+        """
+        return self.__class__(
+            data=data if data is not None else list(self._data),
+            grid_shape=self._grid_shape,
+            block_shape=self._block_shape,
+            original_shape=self._original_shape,
+            batch_size=self._batch_size,
+            order=self._order,
+        )
+
+    def same_layout(self, other: Any) -> bool:
+        """Return ``True`` if layout metadata and encryption status match."""
+        attrs = (
+            "original_shape",
+            "shape",
+            "batch_size",
+            "order",
+            "block_shape",
+            "grid_shape",
+            "is_encrypted",
+        )
+        if not all(hasattr(other, attr) for attr in attrs):
+            return False
+
+        return (
+            self._original_shape == other.original_shape
+            and self._shape == other.shape
+            and self._batch_size == other.batch_size
+            and self._order == other.order
+            and self._block_shape == other.block_shape
+            and self._grid_shape == other.grid_shape
+            and self.is_encrypted == other.is_encrypted
+        )
+
+    def same_metadata(self, other: Any) -> bool:
+        """Return ``True`` if layout metadata, encryption status, and dtype match."""
+        return self.same_layout(other) and getattr(other, "dtype", None) == self._dtype
+
+    def __eq__(self, other: Any) -> bool:
+        """Return metadata-only equality.
+
+        This does not compare encoded block values. For encrypted tensors, value
+        equality is generally not directly observable without decryption.
+        """
+        return self.same_metadata(other)
+
+    def __repr__(self) -> str:
+        """Return a compact representation of block tensor metadata."""
+        return (
+            f"{self.__class__.__name__}("
+            f"original_shape={self._original_shape}, "
+            f"shape={self._shape}, "
+            f"block_shape={self._block_shape}, "
+            f"grid_shape={self._grid_shape}, "
+            f"num_blocks={self.num_blocks}, "
+            f"batch_size={self._batch_size}, "
+            f"slot_utilization={self.slot_utilization:.3f}, "
+            f"order={self._order})"
+        )

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -36,8 +36,10 @@ This module provides functions to create FHE array from various input types,
 including support for block-based tensor operations.
 """
 
+from __future__ import annotations
 # Third‐party imports
-from typing import Literal, Optional, Union
+from math import ceil, prod
+from typing import Any, Literal
 import numpy as np
 from openfhe import CryptoContext, PublicKey
 
@@ -59,49 +61,209 @@ from openfhe_numpy.utils.typecheck import (
 
 
 # Tensor imports
+from .tensor import FHETensor, PackedArrayInformation
 from .ctarray import CTArray
 from .ptarray import PTArray
-from .tensor import FHETensor, PackedArrayInformation
+from .block_tensor import BlockFHETensor
+from .block_ctarray import BlockCTArray
+from .block_ptarray import BlockPTArray
 
 
-def _get_block_dimensions(data: np.ndarray, slots: int) -> tuple[int, int]:
-    """
-    TODO: Compute the block‐matrix dimensions (rows, cols)
-    given raw `data` and number of slots.
-    """
-    pass
-
-
-def block_array(
-    cc: CryptoContext,
-    data: np.ndarray | Number | list,
-    batch_size: Optional[int] = None,
+def _shape(data: Any) -> tuple[int, ...]:
+    """Return NumPy-style shape."""
+    if isinstance(data, Number):
+        return ()
+    shape = getattr(data, "shape", None)
+    if shape is None:
+        shape = np.shape(data)
+    return tuple(shape)
+def _compute_block_dimensions(
+    shape: tuple[int, ...],
+    batch_size: int,
+    block_shape: tuple[int, ...] | None = None,
     order: int = ArrayEncodingType.ROW_MAJOR,
-    fhe_type: Literal["C", "P"] = "C",
+    target_cols: int | None = None,
+    compact: bool = False,
+) -> tuple[int, ...]:
+    """Choose block dimensions if block_shape is None.
+    Default rules:
+        Vector  (n,)    -> (batch_size,), or (side,) where
+                           side = 2^floor(log2(batch_size)/2) if compact=True
+        Column  (m, 1)  -> (batch_size, 1)
+        Row     (1, n)  -> (1, batch_size)
+        General (m, n)  -> (side, side) where side = 2^floor(log2(batch_size)/2)
+    ``compact=True`` requests the smaller, square-compatible vector block
+    size required to pair a block vector with a block matrix for block
+    matrix-vector multiplication (see ``block_array``'s ``compact``
+    parameter). Plain block vectors used for vector-vector arithmetic
+    (add/sub/multiply/dot/matmul) should use the default, non-compact sizing.
+    TODO:
+    [OPTIONAL] For rectangular matrices where one dimension fits in a single
+    block, use rectangular block_shape to reduce wasted slots.
+    """
+    if len(shape) not in (1, 2):
+        raise ValueError(f"Only 1-D or 2-D shapes are supported; got {shape}.")
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive; got {batch_size}.")
+    if any(dim <= 0 for dim in shape):
+        raise ValueError(f"shape must be positive; got {shape}.")
+    if block_shape is not None:
+        block_shape = tuple(block_shape)
+        if len(block_shape) != len(shape):
+            raise ValueError(
+                f"block_shape rank must match shape rank; "
+                f"got block_shape={block_shape}, shape={shape}."
+            )
+        if any(dim <= 0 for dim in block_shape):
+            raise ValueError(f"block_shape must be positive; got {block_shape}.")
+        if prod(block_shape) > batch_size:
+            raise ValueError(
+                f"block_shape={block_shape} uses {prod(block_shape)} slots, "
+                f"but batch_size={batch_size}."
+            )
+        if len(block_shape) == 2:
+            br, bc = block_shape
+            if not is_power_of_two(br) or not is_power_of_two(bc):
+                raise ValueError(
+                    f"Matrix block dimensions must be powers of two; got block_shape={block_shape}."
+                )
+        return block_shape
+    if target_cols is not None:
+        if len(shape) != 1:
+            raise ValueError("target_cols is only valid for block vectors.")
+        if not isinstance(target_cols, int) or target_cols <= 0:
+            raise ValueError(f"target_cols must be a positive integer, got {target_cols!r}.")
+        if target_cols > batch_size:
+            raise ValueError(f"target_cols={target_cols} exceeds batch_size={batch_size}.")
+        return (target_cols,)
+    if len(shape) == 1:
+        if not compact:
+            return (batch_size,)
+        side = 1 << ((batch_size.bit_length() - 1) // 2)
+        return (side,)
+    m, n = shape
+    if n == 1:
+        return (batch_size, 1)
+    if m == 1:
+        return (1, batch_size)
+    side = 1 << ((batch_size.bit_length() - 1) // 2)
+    return (side, side)
+
+
+def _compute_grid_shape(
+    original_shape: tuple[int, ...],
+    block_shape: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Return the number of blocks along each dimension."""
+    if len(original_shape) != len(block_shape):
+        raise ValueError(
+            f"original_shape and block_shape must have the same rank; "
+            f"got original_shape={original_shape}, block_shape={block_shape}."
+        )
+    return tuple(ceil(s / b) for s, b in zip(original_shape, block_shape))
+def block_array(
+    cc,
+    data: np.ndarray | list,
+    block_shape: tuple | None = None,
+    batch_size: int | None = None,
+    order: int = ArrayEncodingType.ROW_MAJOR,
     mode: str = "tile",
-    package: Optional[dict] = None,
-    public_key: PublicKey = None,
-    **kwargs,
-) -> FHETensor:
+    fhe_type: Literal["C", "P"] = "C",
+    public_key=None,
+    target_cols: int | None = None,
+    compact: bool = False,
+) -> BlockFHETensor:
+    """Construct a block plaintext/ciphertext tensor.
+    Tiles the input into encoded blocks, zero-pads edge blocks, and
+    returns a BlockCTArray or BlockPTArray.
+    ``compact`` (vectors only) requests the duplicated, square-compatible
+    packing (e.g. ROW_MAJOR -> [x0, x0, x1, x1]) required to pair a block
+    vector with a block matrix for block matrix-vector multiplication.
+    Leave it False (default) for plain block-vector arithmetic
+    (add/sub/multiply/dot/matmul) -- compact packing duplicates each
+    element, which corrupts summation-based ops like dot/matmul if used
+    outside of block matvec. Passing an explicit ``target_cols`` implies
+    ``compact=True``.
+    For advanced users who already have encoded blocks, call
+    BlockCTArray(...) or BlockPTArray(...) directly.
     """
-    Construct a block‐plaintext or block‐ciphertext array from raw input.
+    if cc is None:
+        raise ValueError("CryptoContext is required.")
+    if fhe_type not in ("C", "P"):
+        raise ValueError(f"fhe_type must be 'C' or 'P'; got {fhe_type!r}.")
+    if fhe_type == "C" and public_key is None:
+        raise ValueError("public_key is required for encryption.")
 
-    Parameters
-    ----------
-    cc         : CryptoContext
-    data       : np.ndarray | Number | list
-    batch_size : Optional[int]
-    order      : ArrayEncodingType
-    type      : "C" for ciphertext, "P" for plaintext
-    mode       : padding mode ("tile" or "zero")
-    package    : Optional prepacked dict from `_pack_array`
-    public_key : PublicKey (required for encryption)
+    if batch_size is None:
+        batch_size = cc.GetBatchSize()
+    arr = np.asarray(data)
+    original_shape = arr.shape
+    if arr.ndim == 0:
+        raise ValueError("Scalar input not supported. Use array() instead.")
+    if arr.ndim > 2:
+        raise ValueError(f"Only 1-D and 2-D supported; got shape {arr.shape}.")
+    is_compact = compact or target_cols is not None
+    block_shape = _compute_block_dimensions(
+        original_shape,
+        batch_size,
+        block_shape,
+        order=order,
+        target_cols=target_cols,
+        compact=is_compact,
+    )
+    grid_shape = _compute_grid_shape(original_shape, block_shape)
+    block_cls = BlockCTArray if fhe_type == "C" else BlockPTArray
+    blocks = []
+    if arr.ndim == 1:
+        chunk = block_shape[0]
+        for i in range(grid_shape[0]):
+            start = i * chunk
+            stop = min(start + chunk, original_shape[0])
+            tile = np.zeros(block_shape, dtype=arr.dtype)
+            tile[: stop - start] = arr[start:stop]
+            # matrix-vector multiplication.
+            vector_target_cols = chunk if is_compact and chunk * chunk <= batch_size else None
+            blocks.append(
+                array(
+                    cc=cc,
+                    data=tile,
+                    batch_size=batch_size,
+                    order=order,
+                    mode=mode,
+                    fhe_type=fhe_type,
+                    public_key=public_key,
+                    target_cols=vector_target_cols,
+                )
+            )
+    else:
+        br, bc = block_shape
+        for gi in range(grid_shape[0]):
+            r0, r1 = gi * br, min((gi + 1) * br, original_shape[0])
+            for gj in range(grid_shape[1]):
+                c0, c1 = gj * bc, min((gj + 1) * bc, original_shape[1])
+                tile = np.zeros(block_shape, dtype=arr.dtype)
+                tile[: r1 - r0, : c1 - c0] = arr[r0:r1, c0:c1]
+                blocks.append(
+                    array(
+                        cc=cc,
+                        data=tile,
+                        batch_size=batch_size,
+                        order=order,
+                        mode=mode,
+                        fhe_type=fhe_type,
+                        public_key=public_key,
+                    )
+                )
 
-    Returns
-    -------
-    FHETensor
-    """
-    pass
+    return block_cls(
+        data=blocks,
+        grid_shape=grid_shape,
+        block_shape=block_shape,
+        original_shape=original_shape,
+        batch_size=batch_size,
+        order=order,
+    )
+
 
 
 def _pack_array(
@@ -176,11 +338,11 @@ def _pack_array(
 def array(
     cc: CryptoContext,
     data: np.ndarray | Number | list,
-    batch_size: Optional[int] = None,
+    batch_size: int | None = None,
     order: int = ArrayEncodingType.ROW_MAJOR,
     fhe_type: Literal["C", "P"] = "P",
     mode: str = "tile",
-    package: Optional[PackedArrayInformation] = None,
+    package: PackedArrayInformation | None = None,
     public_key: PublicKey = None,
     **kwargs,
 ) -> FHETensor:
@@ -209,7 +371,7 @@ def array(
     if not isinstance(batch_size, int) or batch_size < 0:
         raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
-    if not package:
+    if package is None:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
 
     try:
@@ -277,10 +439,9 @@ def _ravel_matrix(
 
     if order == ArrayEncodingType.ROW_MAJOR:
         return _pack_matrix_row_wise(data, batch_size, pad_to_pow2, mode)
-    elif order == ArrayEncodingType.COL_MAJOR:
+    if order == ArrayEncodingType.COL_MAJOR:
         return _pack_matrix_col_wise(data, batch_size, pad_to_pow2, mode)
-    else:
-        raise ValueError("Unsupported encoding order")
+    raise ValueError(f"Unsupported encoding order: {order}")
 
 
 def _ravel_vector(
@@ -315,7 +476,7 @@ def _ravel_vector(
     """
     target_cols = kwargs.get("target_cols")
     if target_cols is not None and not (isinstance(target_cols, int) and target_cols > 0):
-        raise ONPError(f"target_cols must be positive int or None, got {target_cols!r}.")
+        raise ONPError(f"target_cols must be a positive int or None, got {target_cols!r}.")
 
     pad_value = kwargs.get("pad_value", "tile")
     expand = kwargs.get("expand", "tile")
@@ -330,8 +491,8 @@ def _ravel_vector(
             pad_to_power_of_2=pad_to_pow2,
             pad_value=pad_value,
         )
-    elif order == ArrayEncodingType.COL_MAJOR:
-        return _pack_vector_row_wise(
+    if order == ArrayEncodingType.COL_MAJOR:
+        return _pack_vector_col_wise(
             vector=data,
             batch_size=batch_size,
             target_cols=target_cols,
@@ -340,5 +501,4 @@ def _ravel_vector(
             pad_to_power_of_2=pad_to_pow2,
             pad_value=pad_value,
         )
-    else:
-        raise ONPError("Unsupported encoding order")
+    raise ONPError(f"Unsupported encoding order: {order}")

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -30,7 +30,7 @@
 # ==================================================================================
 
 """
-Array constructor functions for OpenFHE-NumPy.
+Constructor functions for OpenFHE-NumPy.
 
 This module provides functions to create FHE array from various input types,
 including support for block-based tensor operations.
@@ -43,7 +43,7 @@ from openfhe import CryptoContext, PublicKey
 
 # Package-level imports
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.matlib import is_power_of_two
 from openfhe_numpy.utils.packing import (
     _pack_matrix_col_wise,
@@ -136,11 +136,11 @@ def _pack_array(
       - order          : int
     """
     if batch_size < 0:
-        ONP_ERROR("The batch size cannot be negative.")
+        raise ONPError("The batch size cannot be negative.")
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two.")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two.")
 
-    data = np.array(data)
+    data = np.asarray(data)
 
     if is_numeric_scalar(data):
         if mode == "zero":
@@ -149,7 +149,7 @@ def _pack_array(
         elif mode == "tile":
             packed = np.full(batch_size, data)
         else:
-            ONP_ERROR(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
+            raise ONPError(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
         shape = (batch_size, 1)
 
     elif is_numeric_arraylike(data):
@@ -158,10 +158,10 @@ def _pack_array(
         elif data.ndim == 1:
             packed, shape = _ravel_vector(data, batch_size, order, True, mode, **kwargs)
         else:
-            ONP_ERROR(f"Unsupported data dimension [{data.ndim}].")
+            raise ONPError(f"Unsupported data dimension [{data.ndim}].")
 
     else:
-        ONP_ERROR("Input is not numeric.")
+        raise ONPError("Input is not numeric.")
 
     return PackedArrayInformation(
         data=packed,
@@ -202,12 +202,12 @@ def array(
     FHETensor
     """
     if cc is None:
-        ONP_ERROR("CryptoContext does not exist")
+        raise ONPError("CryptoContext does not exist")
 
     if batch_size is None:
         batch_size = cc.GetBatchSize()
     if not isinstance(batch_size, int) or batch_size < 0:
-        ONP_ERROR(f"batch_size must be a non-negative int or None, got {batch_size}.")
+        raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
     if not package:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
@@ -215,7 +215,7 @@ def array(
     try:
         plaintext = cc.MakeCKKSPackedPlaintext(package.data)
     except Exception as e:
-        ONP_ERROR("Error: " + str(e))
+        raise ONPError("Error: " + str(e))
 
     if fhe_type == "P":
         return PTArray(
@@ -227,7 +227,7 @@ def array(
         )
     elif fhe_type == "C":
         if public_key is None:
-            ONP_ERROR("Public key must be provided for ciphertext encoding.")
+            raise ONPError("Public key must be provided for ciphertext encoding.")
         try:
             ciphertext = cc.Encrypt(public_key, plaintext)
             return CTArray(
@@ -238,9 +238,9 @@ def array(
                 package.order,  # order
             )
         except Exception as e:
-            ONP_ERROR(f"Failed to encrypt: {e}")
+            raise ONPError(f"Failed to encrypt: {e}")
     else:
-        ONP_ERROR(f"type must be 'C' or 'P', got '{fhe_type}'.")
+        raise ONPError(f"type must be 'C' or 'P', got '{fhe_type}'.")
 
 
 def _ravel_matrix(
@@ -315,7 +315,7 @@ def _ravel_vector(
     """
     target_cols = kwargs.get("target_cols")
     if target_cols is not None and not (isinstance(target_cols, int) and target_cols > 0):
-        ONP_ERROR(f"target_cols must be positive int or None, got {target_cols!r}.")
+        raise ONPError(f"target_cols must be positive int or None, got {target_cols!r}.")
 
     pad_value = kwargs.get("pad_value", "tile")
     expand = kwargs.get("expand", "tile")
@@ -341,4 +341,4 @@ def _ravel_vector(
             pad_value=pad_value,
         )
     else:
-        ONP_ERROR("Unsupported encoding order")
+        raise ONPError("Unsupported encoding order")

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -52,6 +52,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
     """
 
     tensor_priority = 10
+    is_encrypted = True
 
     @property
     def crypto_context(self):
@@ -312,9 +313,18 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
     def __repr__(self) -> str:
         return f"CTArray(metadata={self.metadata})"
 
-    def _sum(self) -> "CTArray":
-        # TODO: implement sum over encrypted data
-        pass
+    def __neg__(self) -> "CTArray":
+        """Return the homomorphic negation of this ciphertext array."""
+        cc = self.data.GetCryptoContext()
+        return self.clone(cc.EvalNegate(self.data))
+
+    def sum(self, axis=None, keepdims: bool = False) -> "CTArray":
+        """Sum tensor elements over an axis."""
+        return self.__tensor_function__(
+            "sum",
+            (self,),
+            {"axis": axis, "keepdims": keepdims},
+        )
 
     def _transpose(self) -> "CTArray":
         """Internal function to evaluate transpose of an encrypted array."""
@@ -337,7 +347,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             self.order,
         )
 
-    def cumulative_sum(self, axis: int = 0) -> "CTArray":
+    def cumsum(self, axis: int = 0) -> "CTArray":
         """
         Compute the cumulative sum of tensor elements along a given axis.
 
@@ -368,7 +378,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         if axis is None:
             ciphertext = EvalSumCumRows(self.data, self.ncols, self.original_shape[1])
 
-        # cumulative_sum over rows
+        # cumsum over rows
         elif axis == 0:
             if self.order == ArrayEncodingType.ROW_MAJOR:
                 ciphertext = EvalSumCumRows(self.data, self.ncols, self.original_shape[1])
@@ -379,7 +389,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             else:
                 raise ONPError(f"Not support this packing order [{self.order}].")
 
-        # cumulative_sum over cols
+        # cumsum over cols
         elif axis == 1:
             if self.order == ArrayEncodingType.ROW_MAJOR:
                 ciphertext = EvalSumCumCols(self.data, self.ncols)

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -30,7 +30,7 @@
 # ==================================================================================
 
 import io
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Callable, Any
 import numpy as np
 import openfhe
 
@@ -413,3 +413,40 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             raise ValueError("Invalid order.")
 
         return sum_rows_key
+
+    def apply(self, func: Callable, *args: Any, **kwargs: Any) -> "CTArray":
+        """Apply a ciphertext-level function to the underlying ciphertext.
+
+        The function must accept ``self.data`` as its first argument and return an
+        OpenFHE ciphertext with the same logical packing layout.
+
+        Parameters
+        ----------
+        func : Callable
+            Function applied to the underlying ciphertext.
+        *args : Any
+            Additional positional arguments passed to ``func``.
+        **kwargs : Any
+            Additional keyword arguments passed to ``func``.
+
+        Returns
+        -------
+        CTArray
+            A new CTArray with the same shape/metadata but the transformed ciphertext.
+
+        Examples
+        --------
+        Bootstrap to refresh noise level:
+
+        ``result = a.apply(cc.EvalBootstrap)``
+
+        Chebyshev-style functions can be wrapped when the ciphertext is not the
+        first argument:
+
+        ``result = a.apply(lambda ct: cc.EvalChebyshevSeries(ct, coeffs, -8, 8))``
+        """
+        if not callable(func):
+            raise TypeError(f"apply expects a callable, got {type(func).__name__}.")
+
+        ct_result = func(self.data, *args, **kwargs)
+        return self.clone(data=ct_result)

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -38,7 +38,7 @@ import openfhe
 from ..openfhe_numpy import EvalSumCumCols, EvalSumCumRows, EvalTranspose, ArrayEncodingType
 from ..utils.matlib import next_power_of_two
 from ..utils.constants import UnpackType
-from ..utils.errors import ONP_ERROR
+from ..utils.errors import ONPError
 from ..utils.packing import process_packed_data
 from ..utils._helper_slots_ops import _get_single_element
 
@@ -243,12 +243,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             The decrypted data, formatted by 'unpack_type'.
         """
         if secret_key is None:
-            ONP_ERROR("Secret key is missing.")
+            raise ONPError("Secret key is missing.")
 
         cc = self.data.GetCryptoContext()
         plaintext = cc.Decrypt(self.data, secret_key)
         if plaintext is None:
-            ONP_ERROR("Decryption failed.")
+            raise ONPError("Decryption failed.")
 
         plaintext.SetLength(self.batch_size)
         result = plaintext.GetRealPackedValue()
@@ -269,7 +269,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
         stream = io.BytesIO()
         if not openfhe.Serialize(self.data, stream):
-            ONP_ERROR("Failed to serialize ciphertext.")
+            raise ONPError("Failed to serialize ciphertext.")
 
         return {
             "type": self.type,
@@ -294,12 +294,12 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         ]
         for key in required_keys:
             if key not in obj:
-                ONP_ERROR(f"Missing required key '{key}' in serialized object.")
+                raise ONPError(f"Missing required key '{key}' in serialized object.")
 
         stream = io.BytesIO(bytes.fromhex(obj["ciphertext"]))
         ciphertext = openfhe.Ciphertext()
         if not openfhe.Deserialize(ciphertext, stream):
-            ONP_ERROR("Failed to deserialize ciphertext.")
+            raise ONPError("Failed to deserialize ciphertext.")
 
         return cls(
             ciphertext,
@@ -353,13 +353,13 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         """
 
         if self.ndim != 1 and self.ndim != 2:
-            ONP_ERROR(f"Dimension of array {self.ndim} is illegal ")
+            raise ONPError(f"Dimension of array {self.ndim} is illegal ")
 
         if self.ndim != 1 and axis is None:
-            ONP_ERROR("axis=None not allowed for >1D")
+            raise ONPError("axis=None not allowed for >1D")
 
         if self.ndim == 2 and axis not in (0, 1):
-            ONP_ERROR("Axis must be 0 or 1 for cumulative sum operation")
+            raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
 
         order = self.order
         shape = self.shape
@@ -377,7 +377,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumCols(self.data, self.nrows)
 
             else:
-                raise ONP_ERROR(f"Not support this packing order [{self.order}].")
+                raise ONPError(f"Not support this packing order [{self.order}].")
 
         # cumulative_sum over cols
         elif axis == 1:
@@ -388,9 +388,9 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 ciphertext = EvalSumCumRows(self.data, self.nrows, self.original_shape[0])
 
             else:
-                raise ONP_ERROR(f"Not support this packing order[{self.order}].")
+                raise ONPError(f"Not support this packing order[{self.order}].")
         else:
-            raise ONP_ERROR(f"Invalid axis [{axis}].")
+            raise ONPError(f"Invalid axis [{axis}].")
         return CTArray(ciphertext, original_shape, self.batch_size, shape, order)
 
     def gen_sum_row_key(self, secret_key: openfhe.PrivateKey) -> openfhe.EvalKey:

--- a/openfhe_numpy/tensor/ptarray.py
+++ b/openfhe_numpy/tensor/ptarray.py
@@ -29,8 +29,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
+import numpy as np
 from .tensor import FHETensor  # Use relative import
 from .ctarray import CTArray
+from ..utils.constants import UnpackType
+from ..utils.packing import process_packed_data
 from openfhe import Plaintext, CryptoContext, PublicKey
 
 
@@ -40,12 +43,14 @@ from openfhe import Plaintext, CryptoContext, PublicKey
 class PTArray(FHETensor[Plaintext]):
     """Concrete tensor class for OpenFHE plaintexts."""
 
+    is_encrypted = False
+
     def clone(self, data=None):
         return PTArray(
             data or self.data,
             self.original_shape,
             self.batch_size,
-            self.ncols,
+            self.shape,
             self.order,
         )
 
@@ -62,8 +67,20 @@ class PTArray(FHETensor[Plaintext]):
     def decrypt(self, *args, **kwargs):
         raise NotImplementedError("Decrypt not implemented for plaintext")
 
+    def decode(self, unpack_type: UnpackType = UnpackType.ORIGINAL) -> np.ndarray:
+        """Decode plaintext packed slots into a NumPy array."""
+        self.data.SetLength(self.batch_size)
+        result = self.data.GetRealPackedValue()
+        if isinstance(unpack_type, str):
+            unpack_type = UnpackType(unpack_type.lower())
+        if unpack_type == UnpackType.RAW:
+            return np.asarray(result)
+        if unpack_type == UnpackType.ORIGINAL:
+            return process_packed_data(result, self.info)
+        return np.asarray(result)
+
     def __repr__(self) -> str:
-        return f"PTArray(meta={self.metadata})"
+        return f"PTArray(meta={self.info})"
 
     def serialize(self) -> dict:
         raise NotImplementedError("Serialize not implemented for plaintext")

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -48,6 +48,8 @@ TPL = TypeVar("Template")
 # BaseTensor - Abstract Interface
 # Don't implement anything here
 class BaseTensor(ABC, Generic[TPL]):
+    is_encrypted: bool = False
+
     @property
     @abstractmethod
     def shape(self) -> Tuple[int, ...]: ...
@@ -128,6 +130,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         "_dtype",
         "extra",
     )
+    is_encrypted = False
 
     @overload
     def __init__(
@@ -197,7 +200,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
 
     @property
     def data(self) -> TPL:
-        """Underlying encrypted/plaintext payload."""
+        """Underlying encrypted/plaintext."""
         return self._data
 
     @data.setter
@@ -371,14 +374,29 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     def __matmul__(self, other):
         return self.__tensor_function__("matmul", (self, other))
 
-    def __pow__(self, exp):
-        return self.__tensor_function__("power", (self, exp))
+    def __pow__(self, exponent):
+        return self.__tensor_function__("power", (self, exponent))
 
-    # Replace these methods too
-    def sum(self, axis=0):
-        if axis < 0 or axis >= self.ndim:
-            raise ValueError(f"Invalid axis {axis} for tensor with {self.ndim} dimensions.")
-        return self.__tensor_function__("sum", (self,), {"axis": axis})
+    def sum(self, axis=None, keepdims=False):
+        """
+        Sum tensor entries over all elements or one axis.
+        Remark: Tuple axes are not supported
+        """
+        if axis is not None:
+            if not isinstance(axis, int):
+                raise TypeError(f"axis must be None or an integer, got {type(axis).__name__}.")
+
+            if axis < 0:
+                axis += self.ndim
+
+            if axis < 0 or axis >= self.ndim:
+                raise ValueError(f"Invalid axis {axis} for tensor with {self.ndim} dimensions.")
+
+        return self.__tensor_function__(
+            "sum",
+            (self,),
+            {"axis": axis, "keepdims": keepdims},
+        )
 
     def reduce(self, axis=0):
         return self.__tensor_function__("reduce", (self,), {"axis": axis})

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -37,7 +37,7 @@ from typing import overload, Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 import numpy as np
 
 # Internal C++ module Imports
-from openfhe_numpy.utils.errors import ONP_ERROR
+from openfhe_numpy.utils.errors import ONPError
 from openfhe_numpy.utils.constants import *
 
 # -----------------------------------------------------------
@@ -162,7 +162,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             self.extra = {}
         else:
             if None in (original_shape, batch_size, new_shape):
-                ONP_ERROR(
+                raise ONPError(
                     "Raw form requires (data, original_shape, ndim, batch_size, shape[, order])"
                 )
             self._data = data
@@ -172,7 +172,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
 
             self._ndim = len(original_shape)
             if self._ndim > 2 or self._ndim < 0:
-                ONP_ERROR("Dimension is invalid!!!")
+                raise ONPError("Dimension is invalid!!!")
             self._order = order
             self._dtype = self.__class__.__name__
             self._zeros = None
@@ -209,7 +209,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         elif isinstance(data, openfhe.Plaintext):
             self._dtype = "PTArray"
         else:
-            ONP_ERROR(
+            raise ONPError(
                 "Object data is incorrect. \
                       Only support FHETensor only supports Ciphertext or Plaintext"
             )
@@ -274,7 +274,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         if order in ["R", "C"]:
             self._order = order
         else:
-            ONP_ERROR("Not support order [{order}]")
+            raise ONPError(f"Not support order [f{order}]")
 
     @property
     def is_encrypted(self) -> int:
@@ -296,6 +296,17 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     @property
     def T(self):
         return self.transpose()
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"original_shape={self.original_shape}, "
+            f"batch_size={self.batch_size}, "
+            f"shape={self.shape}, "
+            f"order={self.order}, "
+            f"ndim={self.ndim}, "
+            f"extra={self.extra})"
+        )
 
     ###
     ### Update properties in some specific cases

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -28,252 +28,288 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
-
 """Logging and error handling for OpenFHE-NumPy.
 
 This module provides:
-1. A configured logger with consistent log formatting
-2. Custom exceptions with stack trace information
-3. Convenience functions for logging at different levels
-4. Configuration management via environment variables
+1. A package-level logger for OpenFHE-NumPy.
+2. Custom exception classes for user-facing tensor errors.
+3. Convenience logging helpers.
+4. Optional logging configuration through environment variables.
 
-Environment Variables:
-    OPENFHE_DEBUG: Enable debug logging ("ON", "1", "TRUE")
-    OPENFHE_LOG_FORMAT: Custom log format string
-    OPENFHE_LOG_FILE: Path to log file (optional)
-    OPENFHE_LOG_MAX_SIZE: Maximum log file size in bytes
-    OPENFHE_LOG_BACKUP_COUNT: Number of backup log files
+Logging policy
+--------------
+Default behavior:
+    No logs are printed by OpenFHE-NumPy.
 
-Usage::
-    from openfhe_numpy.utils.errors import ONP_DEBUG, ONP_ERROR, ONP_WARNING
+If the user sets OPENFHE_DEBUG or OPENFHE_LOG_FILE:
+    OpenFHE-NumPy configures its own logging.
 
-    ONP_DEBUG("Processing data...")
-    ONP_WARNING("Unusual input detected")
-    if problem:
-        ONP_ERROR("Invalid input data")
+If the application configures logging itself:
+    OpenFHE-NumPy respects that configuration.
+
+Environment variables
+---------------------
+OPENFHE_DEBUG:
+    Enable debug logging when set to "ON", "1", "TRUE", or "YES".
+
+OPENFHE_LOG_FORMAT:
+    Custom logging format string.
+
+OPENFHE_LOG_FILE:
+    Optional path to a log file.
+
+OPENFHE_LOG_MAX_SIZE:
+    Maximum rotating log file size in bytes. Default: 10MB.
+
+OPENFHE_LOG_BACKUP_COUNT:
+    Number of rotated backup log files. Default: 5.
+
+Backward compatibility
+----------------------
+FP_ENABLE_DEBUG:
+    Also enables debug logging when set to "ON", "1", "TRUE", or "YES".
 """
 
-import inspect
-import os
+from __future__ import annotations
+
 import logging
-import threading
-import traceback
-from typing import Any, Dict
+import os
+import warnings
 from logging.handlers import RotatingFileHandler
-
-# === Configuration ===
-
-# Default configuration values
-DEFAULT_CONFIG = {
-    "enable_debug": False,
-    "log_format": "%(asctime)s - %(levelname)s - %(message)s",
-    "log_file": None,
-    "max_file_size": 10 * 1024 * 1024,  # 10MB
-    "backup_count": 5,
-}
+from typing import Optional
 
 
-def get_config() -> Dict[str, Any]:
-    """Get logging configuration from environment variables with defaults."""
-    return {
-        "enable_debug": os.getenv("OPENFHE_DEBUG", "OFF").upper() in ("ON", "1", "TRUE"),
-        "log_format": os.getenv("OPENFHE_LOG_FORMAT", DEFAULT_CONFIG["log_format"]),
-        "log_file": os.getenv("OPENFHE_LOG_FILE", DEFAULT_CONFIG["log_file"]),
-        "max_file_size": int(
-            os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_CONFIG["max_file_size"]))
-        ),
-        "backup_count": int(
-            os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_CONFIG["backup_count"]))
-        ),
-    }
+# =============================================================================
+# Logging configuration
+# =============================================================================
+
+LOGGER_NAME = "openfhe_numpy"
+
+_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_BACKUP_COUNT = 5
 
 
-# Load configuration (done once at module import time)
-_config = get_config()
+def _env_flag_enabled(name: str, default: str = "OFF") -> bool:
+    """Return True if an environment flag is enabled."""
+    return os.getenv(name, default).upper() in {"ON", "1", "TRUE", "YES"}
 
-# For backward compatibility
-ENABLE_DEBUG = _config["enable_debug"]
-if os.getenv("FP_ENABLE_DEBUG", "OFF").upper() == "ON":
-    ENABLE_DEBUG = True
-    _config["enable_debug"] = True
 
-_logger = None
-_logger_lock = threading.Lock()
+def debug_enabled() -> bool:
+    """Return whether OpenFHE-NumPy debug logging is enabled."""
+    return _env_flag_enabled("OPENFHE_DEBUG") or _env_flag_enabled("FP_ENABLE_DEBUG")
+
+
+def _explicit_logging_requested() -> bool:
+    """Return True if OpenFHE-NumPy should configure its own logging."""
+    return (
+        debug_enabled()
+        or os.getenv("OPENFHE_LOG_FILE") is not None
+        or os.getenv("OPENFHE_LOG_FORMAT") is not None
+    )
 
 
 def get_logger() -> logging.Logger:
-    """Thread-safe singleton logger with console + optional rotating file output."""
-    global _logger
-    if _logger is None:
-        with _logger_lock:
-            if _logger is None:
-                _logger = logging.getLogger("openfhe_numpy")
+    """Return the OpenFHE-NumPy package logger.
 
-                if not _logger.handlers:
-                    formatter = logging.Formatter(_config["log_format"])
+    By default, the logger is silent and uses ``NullHandler``. This is the
+    recommended behavior for open-source libraries: importing the package should
+    not unexpectedly print logs.
 
-                    # Rotating file handler (optional)
-                    log_file = _config["log_file"]
-                    if log_file:
-                        try:
-                            file_handler = RotatingFileHandler(
-                                log_file,
-                                maxBytes=_config["max_file_size"],
-                                backupCount=_config["backup_count"],
-                            )
-                            file_handler.setFormatter(formatter)
-                            _logger.addHandler(file_handler)
-                        except Exception as e:
-                            print(f"Warning: Could not set up file logging: {e}")
+    If ``OPENFHE_DEBUG``, ``FP_ENABLE_DEBUG``, ``OPENFHE_LOG_FILE``, or
+    ``OPENFHE_LOG_FORMAT`` is set, OpenFHE-NumPy configures its own handler.
 
-                    # Console handler
-                    stream_handler = logging.StreamHandler()
-                    stream_handler.setFormatter(formatter)
-                    stream_handler.setLevel(
-                        logging.DEBUG if _config["enable_debug"] else logging.INFO
-                    )
-                    _logger.addHandler(stream_handler)
+    If an application has already configured the ``openfhe_numpy`` logger, this
+    function leaves that configuration unchanged.
+    """
+    logger = logging.getLogger(LOGGER_NAME)
 
-                    _logger.setLevel(logging.DEBUG)
-                    _logger.propagate = False
-    return _logger
+    # Respect application/test configuration.
+    if logger.handlers:
+        return logger
+
+    if not _explicit_logging_requested():
+        logger.addHandler(logging.NullHandler())
+        logger.propagate = True
+        return logger
+
+    handler_level = logging.DEBUG if debug_enabled() else logging.INFO
+    log_format = os.getenv("OPENFHE_LOG_FORMAT", _LOG_FORMAT)
+    formatter = logging.Formatter(log_format)
+
+    # Console handler is enabled only when logging is explicitly requested.
+    if debug_enabled() or os.getenv("OPENFHE_LOG_FORMAT") is not None:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(handler_level)
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
+
+    # Optional rotating file handler.
+    log_file = os.getenv("OPENFHE_LOG_FILE")
+    if log_file:
+        try:
+            max_file_size = int(os.getenv("OPENFHE_LOG_MAX_SIZE", str(DEFAULT_MAX_FILE_SIZE)))
+            backup_count = int(os.getenv("OPENFHE_LOG_BACKUP_COUNT", str(DEFAULT_BACKUP_COUNT)))
+
+            file_handler = RotatingFileHandler(
+                log_file,
+                maxBytes=max_file_size,
+                backupCount=backup_count,
+            )
+            file_handler.setLevel(handler_level)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+        except Exception as exc:
+            warnings.warn(
+                f"Could not set up OpenFHE-NumPy file logging: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    # Keep logger permissive; handlers decide what to emit.
+    logger.setLevel(logging.DEBUG)
+
+    # Avoid duplicate messages through the root logger once we add handlers.
+    logger.propagate = False
+
+    return logger
 
 
-# === Custom Exceptions ===
+logger = get_logger()
+
+
+# =============================================================================
+# Custom exceptions
+# =============================================================================
 
 
 class ONPError(Exception):
-    """Base class for OpenFHE-NumPy errors."""
-
-    def __init__(self, message: str):
-        stack = traceback.extract_stack(limit=2)[-2]
-        filename = os.path.basename(stack.filename)
-        function_name = stack.name
-        line_number = stack.lineno
-        full_message = f'{message}\n    File: "{filename}", line {line_number}, in {function_name}'
-        super().__init__(full_message)
+    """Base class for all OpenFHE-NumPy errors."""
 
 
 class ONPTypeError(ONPError, TypeError):
-    """Raised when incorrect types are provided."""
-
-    pass
+    """Raised when an object has an invalid type."""
 
 
 class ONPDimensionError(ONPError, ValueError):
-    """Raised when an invalid axis is provided."""
-
-    pass
+    """Raised when a tensor dimension, rank, or axis is invalid."""
 
 
 class ONPValueError(ONPError, ValueError):
     """Raised when an invalid value is encountered."""
 
-    def __init__(self, message: str = "Invalid value encountered."):
+    def __init__(self, message: str = "Invalid value encountered.") -> None:
         super().__init__(message)
 
 
-class ONPIncompatibleShape(ONPValueError, ValueError):
-    """Raised when tensor shapes are incompatible."""
+class ONPIncompatibleShapeError(ONPError, ValueError):
+    """Raised when tensor shapes are incompatible for an operation."""
 
-    def __init__(self, shape_a, shape_b, message: str = None):
+    def __init__(
+        self,
+        shape_a: object,
+        shape_b: object,
+        message: Optional[str] = None,
+    ) -> None:
         if message is None:
             message = f"Incompatible shapes: {shape_a} vs {shape_b}"
         super().__init__(message)
 
 
 class ONPNotImplementedError(ONPError, NotImplementedError):
-    """Raised when a feature is not implemented."""
+    """Raised when a feature is not yet implemented."""
 
-    def __init__(self, message: str = "This feature is not implemented."):
-        super().__init__(f"{message}")
+    def __init__(self, message: str = "This feature is not implemented.") -> None:
+        super().__init__(message)
 
 
 class ONPNotSupportedError(ONPError, NotImplementedError):
-    """Raised when a feature is not supported."""
+    """Raised when a feature is intentionally not supported."""
 
-    def __init__(self, message: str = "This feature is not supported."):
-        super().__init__(f"{message}")
-
-
-# === Logging Helpers ===
+    def __init__(self, message: str = "This feature is not supported.") -> None:
+        super().__init__(message)
 
 
-def _format_log(level: str, message: str, stack_level: int = 2) -> str:
-    frame = inspect.stack()[stack_level]
-    filename = os.path.basename(frame.filename)
-    function_name = frame.function
-    line_number = frame.lineno
-    return f'[{level}] {message}\n    File: "{filename}", line {line_number}, in {function_name}'
-
-
-def _log(level: str, message: str, stack_level: int = 2) -> None:
-    formatted_message = _format_log(level, message, stack_level)
-    logger = get_logger()
-    if level == "ONP_ERROR":
-        logger.error(formatted_message)
-    elif level == "ONP_DEBUG" and ENABLE_DEBUG:
-        logger.debug(formatted_message)
-    elif level == "ONP_WARNING":
-        logger.warning(formatted_message)
-    elif level == "ONP_INFO":
-        logger.info(formatted_message)
-    else:
-        return
-
-
-# === Public API ===
+# =============================================================================
+# Logging helpers
+# =============================================================================
 
 
 def ONP_INFO(message: str) -> None:
-    _log("ONP_INFO", message)
-
-
-def ONP_ERROR(message: str, raise_exception: bool = True) -> None:
-    _log("ONP_ERROR", message)
-    if raise_exception:
-        raise ONPError(message)
+    """Log an informational message."""
+    logger.info(message, stacklevel=2)
 
 
 def ONP_DEBUG(message: str) -> None:
-    _log("ONP_DEBUG", message)
+    """Log a debug message.
+
+    Visibility is controlled by logger and handler levels.
+    """
+    logger.debug(message, stacklevel=2)
 
 
 def ONP_WARNING(message: str) -> None:
-    _log("ONP_WARNING", message)
+    """Log a warning message."""
+    logger.warning(message, stacklevel=2)
+
+
+def ONP_ERROR(message: str) -> None:
+    """Log an error message."""
+    logger.error(message, stacklevel=2)
+
+
+# =============================================================================
+# Testing helper
+# =============================================================================
 
 
 def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
-    """Capture logs for testing.
-
-    Returns a handler that collects logs for inspection in tests.
+    """Attach an in-memory log handler for tests.
 
     Parameters
     ----------
-    level : int, optional
-        Logging level to capture (default: logging.DEBUG)
+    level:
+        Logging level to capture.
 
     Returns
     -------
     logging.Handler
-        A handler with a 'messages' attribute containing captured log messages
+        A handler with a ``messages`` attribute containing formatted log records.
 
     Example
     -------
-    handler = capture_logs()
-    ONP_DEBUG("Test message")
-    assert "Test message" in handler.messages
+    >>> handler = capture_logs()
+    >>> ONP_DEBUG("test message")
+    >>> assert any("test message" in msg for msg in handler.messages)
     """
 
     class MemoryHandler(logging.Handler):
+        """Simple in-memory logging handler."""
+
         def __init__(self) -> None:
             super().__init__(level)
-            self.messages = []
+            self.messages: list[str] = []
 
         def emit(self, record: logging.LogRecord) -> None:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
+    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
-    get_logger().addHandler(handler)
+
+    test_logger = get_logger()
+
+    # Remove the default no-op handler in tests, if present.
+    test_logger.handlers = [
+        existing_handler
+        for existing_handler in test_logger.handlers
+        if not isinstance(existing_handler, logging.NullHandler)
+    ]
+
+    test_logger.addHandler(handler)
+
+    # Make sure debug messages can reach the test handler.
+    test_logger.setLevel(logging.DEBUG)
+
     return handler

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -295,17 +295,13 @@ def capture_logs(level: int = logging.DEBUG) -> logging.Handler:
             self.messages.append(self.format(record))
 
     handler = MemoryHandler()
-    handler.setLevel(level)
     handler.setFormatter(logging.Formatter("%(message)s"))
 
     test_logger = get_logger()
 
-    # Remove the default no-op handler in tests, if present.
-    test_logger.handlers = [
-        existing_handler
-        for existing_handler in test_logger.handlers
-        if not isinstance(existing_handler, logging.NullHandler)
-    ]
+    for existing_handler in list(test_logger.handlers):
+        if isinstance(existing_handler, logging.NullHandler):
+            test_logger.removeHandler(existing_handler)
 
     test_logger.addHandler(handler)
 

--- a/openfhe_numpy/utils/matlib.py
+++ b/openfhe_numpy/utils/matlib.py
@@ -30,8 +30,11 @@
 # ==================================================================================
 
 import math
+from typing import Any, Iterable
+
 import numpy as np
 from .constants import EPSILON
+from .errors import ONPValueError
 
 
 def next_power_of_two(x):
@@ -188,3 +191,18 @@ def _rotate_vector(vec, k):
 
     k %= n
     return vec[k:] + vec[:k]
+
+
+def _sum_terms(terms: Iterable[Any]) -> Any:
+    """Accumulate a non-empty iterable of encoded terms by addition."""
+    iterator = iter(terms)
+
+    try:
+        acc = next(iterator)
+    except StopIteration:
+        raise ONPValueError("Cannot sum an empty sequence of terms.") from None
+
+    for term in iterator:
+        acc = acc + term
+
+    return acc

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -51,7 +51,7 @@ from numpy.typing import ArrayLike
 
 from openfhe_numpy.openfhe_numpy import *
 
-from .errors import ONP_ERROR
+from .errors import ONPError
 from .matlib import is_power_of_two, next_power_of_two
 from .typecheck import *
 
@@ -99,7 +99,7 @@ def _pack_vector_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If expand mode is invalid
@@ -117,7 +117,7 @@ def _pack_vector_row_wise(
     """
 
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -130,7 +130,7 @@ def _pack_vector_row_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     flattened = np.zeros(expanded_size, dtype=np.asarray(vector).dtype)
     if expand == "tile":
@@ -141,21 +141,21 @@ def _pack_vector_row_wise(
             for i in range(n):
                 flattened[i * ncols : (i + 1) * ncols] = vector[i]
         else:
-            ONP_ERROR(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
+            raise ONPError(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
     elif expand == "zero":
         flattened[np.arange(n) * target_cols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size < (expanded_size * tiles):
-        ONP_ERROR(
+        raise ONPError(
             f"Padded vector [{expanded_size} x {tiles}] is longer than the batch size [{batch_size}]"
         )
 
@@ -201,7 +201,7 @@ def _pack_vector_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         - If batch_size is not a power of two
         - If expanded vector size exceeds batch_size
         - If tile_mode is invalid
@@ -217,7 +217,7 @@ def _pack_vector_col_wise(
 
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"Batch size [{batch_size}] must be a power of two")
+        raise ONPError(f"Batch size [{batch_size}] must be a power of two")
 
     n = len(vector)
     nrows = next_power_of_two(n) if pad_to_power_of_2 else n
@@ -229,7 +229,7 @@ def _pack_vector_col_wise(
     expanded_size = nrows * ncols
 
     if batch_size < (expanded_size):
-        ONP_ERROR(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
+        raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     padded = np.zeros(nrows, dtype=vector.dtype)
     padded[:n] = vector
@@ -244,14 +244,14 @@ def _pack_vector_col_wise(
     elif expand == "zero":
         flattened[: n * ncols : ncols] = vector
     else:
-        ONP_ERROR(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
     if tile == "tile":
         tiles = batch_size // expanded_size
     elif tile == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid tile mode: '{tile}'. Valid options are 'zero' or 'tile'.")
 
     total_len = tiles * expanded_size
     output = np.zeros(batch_size, dtype=flattened.dtype)
@@ -300,12 +300,12 @@ def _pack_matrix_row_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If 'batch_size' is not a power of two, not divisible by the padded size,
         or insufficient to hold the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -325,13 +325,13 @@ def _pack_matrix_row_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -383,12 +383,12 @@ def _pack_matrix_col_wise(
 
     Raises
     ------
-    ONP_ERROR
+    ONPError
         If batch_size is not a power of two, or if batch_size is not divisible by
         the required size, or if batch_size is insufficient for the padded matrix.
     """
     if not is_power_of_two(batch_size):
-        ONP_ERROR(f"batch_size [{batch_size}] must be a power of two")
+        raise ONPError(f"batch_size [{batch_size}] must be a power of two")
 
     rows, cols = len(matrix), len(matrix[0])
     nrows, ncols = rows, cols
@@ -408,13 +408,13 @@ def _pack_matrix_col_wise(
     elif mode == "zero":
         tiles = 1
     else:
-        ONP_ERROR(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
+        raise ONPError(f"Invalid padding mode: '{mode}'. Valid options are 'zero' or 'tile'.")
 
     if batch_size % required_size != 0:
-        ONP_ERROR(f"batch_size [{batch_size}] must be divisible by required_size")
+        raise ONPError(f"batch_size [{batch_size}] must be divisible by required_size")
 
     if batch_size < required_size:
-        ONP_ERROR(
+        raise ONPError(
             f"batch_size [{batch_size}] is insufficient for padding  [{required_size * tiles}]."
         )
 
@@ -543,7 +543,7 @@ def _extract_matrix(data, info):
         tranposed = np.transpose(reshaped)
         return tranposed[: info["original_shape"][0], : info["original_shape"][1]]
     else:
-        ONP_ERROR("Order is not supported!!!")
+        raise ONPError("Order is not supported!!!")
         return None
 
 
@@ -572,8 +572,7 @@ def _extract_vector(data, info):
         elif info["order"] == COL_MAJOR:
             return reshaped[0, :original_row]
         else:
-            ONP_ERROR("Order is not supported!!!")
-            return None
+            raise ONPError("Order is not supported!!!")
     else:
         return data[0]
 

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -601,3 +601,9 @@ def process_packed_data(
         return _extract_matrix(data, info)
     else:
         return _extract_vector(data, info)
+def _is_row_major(order: Any) -> bool:
+    """Return True if ``order`` is row-major packing."""
+    return order == ArrayEncodingType.ROW_MAJOR
+def _is_col_major(order: Any) -> bool:
+    """Return True if ``order`` is column-major packing."""
+    return order == ArrayEncodingType.COL_MAJOR

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,7 @@ python3 run_tests.py
 
 # Run tests in a subfolder under cases/
 python3 run_tests.py matrix_ops
-python3 run_tests.py slicing
+
 
 # Run a single tests
 python3 run_tests.py matrix_ops/test_matrix_sum.py

--- a/tests/cases/big_matrix/test_block_matrix.py
+++ b/tests/cases/big_matrix/test_block_matrix.py
@@ -5,10 +5,12 @@ import openfhe_numpy as onp
 from core import *
 
 
-SIZES = [5, 8, 16]
-BLOCK_BATCH_SIZE = 4
+# ckks_params_block.csv uses ringDim=512, so the CKKS slot capacity is 256.
+# A 17 x 17 matrix has 289 entries, forcing block packing because 289 > 256.
+SIZES = [17]
 ORDERS = [("row_major", onp.ROW_MAJOR)]
 MODES = ["zero"]
+BLOCK_PARAMS_CSV = CRYPTO_PARAMS_DIR / "ckks_params_block.csv"
 
 
 def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
@@ -59,12 +61,12 @@ class BlockMatrixTestBase:
         raise NotImplementedError
 
     def test_matrix_operation(self):
-        ckks_params = load_ckks_params()
+        ckks_params = load_ckks_params(BLOCK_PARAMS_CSV)
 
         for _, p in enumerate(ckks_params):
             params = _ensure_depth(p, self.min_depth)
-            max_batch_size = params["ringDim"] // 2
-            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+            slot_capacity = params["ringDim"] // 2
+            batch_size = slot_capacity
 
             if batch_size <= 0:
                 continue
@@ -82,14 +84,14 @@ class BlockMatrixTestBase:
 
             try:
                 for size in SIZES:
-                    if size * size > max_batch_size and batch_size > max_batch_size:
-                        continue
+                    self.assertGreater(size * size, slot_capacity)
 
                     A = generate_random_array(rows=size, cols=size)
                     B = generate_random_array(rows=size, cols=size)
 
                     for order_name, order_value in ORDERS:
                         for mode in MODES:
+                            expected = self.np_fn(A, B)
                             result = None
                             ctm_a = None
                             ctm_b = None
@@ -115,7 +117,6 @@ class BlockMatrixTestBase:
                                     public_key=keys.publicKey,
                                 )
 
-                                expected = self.np_fn(A, B)
                                 ctm_res = self.fhe_fn(ctm_a, ctm_b)
                                 result = ctm_res.decrypt(
                                     keys.secretKey,
@@ -130,6 +131,8 @@ class BlockMatrixTestBase:
                                         "case": "block_matrix_operation",
                                         "op": self.op_name,
                                         "size": size,
+                                        "matrix_slots": size * size,
+                                        "slot_capacity": slot_capacity,
                                         "order": order_name,
                                         "mode": mode,
                                         "batch_size": batch_size,

--- a/tests/cases/big_matrix/test_block_matrix.py
+++ b/tests/cases/big_matrix/test_block_matrix.py
@@ -1,0 +1,211 @@
+import gc
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+from core import *
+
+
+SIZES = [5, 8, 16]
+BLOCK_BATCH_SIZE = 4
+ORDERS = [("row_major", onp.ROW_MAJOR)]
+MODES = ["zero"]
+
+
+def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
+    p = params.copy()
+    if p.get("multiplicativeDepth", 0) < min_depth:
+        p["multiplicativeDepth"] = min_depth
+    return p
+
+
+def _make_block_matrix(
+    cc,
+    data,
+    batch_size,
+    order,
+    mode,
+    fhe_type,
+    public_key=None,
+):
+    kwargs = {
+        "cc": cc,
+        "data": data,
+        "batch_size": batch_size,
+        "block_shape": None,
+        "order": order,
+        "mode": mode,
+        "fhe_type": fhe_type,
+    }
+
+    if fhe_type == "C":
+        kwargs["public_key"] = public_key
+
+    return onp.block_array(**kwargs)
+
+
+class BlockMatrixTestBase:
+    """Base class for one-operation block matrix tests."""
+
+    op_name = None
+    min_depth = 4
+    needs_mult_key = False
+    needs_sum_key = False
+    needs_global_sum_key = False
+
+    def np_fn(self, a, b=None):
+        raise NotImplementedError
+
+    def fhe_fn(self, a, b=None):
+        raise NotImplementedError
+
+    def test_matrix_operation(self):
+        ckks_params = load_ckks_params()
+
+        for _, p in enumerate(ckks_params):
+            params = _ensure_depth(p, self.min_depth)
+            max_batch_size = params["ringDim"] // 2
+            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+
+            if batch_size <= 0:
+                continue
+
+            cc, keys = gen_crypto_context(params)
+
+            if self.needs_mult_key:
+                cc.EvalMultKeyGen(keys.secretKey)
+
+            if self.needs_sum_key:
+                cc.EvalSumKeyGen(keys.secretKey)
+
+            if self.needs_global_sum_key:
+                onp.gen_sum_key(keys.secretKey)
+
+            try:
+                for size in SIZES:
+                    if size * size > max_batch_size and batch_size > max_batch_size:
+                        continue
+
+                    A = generate_random_array(rows=size, cols=size)
+                    B = generate_random_array(rows=size, cols=size)
+
+                    for order_name, order_value in ORDERS:
+                        for mode in MODES:
+                            result = None
+                            ctm_a = None
+                            ctm_b = None
+                            ctm_res = None
+
+                            try:
+                                ctm_a = _make_block_matrix(
+                                    cc=cc,
+                                    data=A,
+                                    batch_size=batch_size,
+                                    order=order_value,
+                                    mode=mode,
+                                    fhe_type="C",
+                                    public_key=keys.publicKey,
+                                )
+                                ctm_b = _make_block_matrix(
+                                    cc=cc,
+                                    data=B,
+                                    batch_size=batch_size,
+                                    order=order_value,
+                                    mode=mode,
+                                    fhe_type="C",
+                                    public_key=keys.publicKey,
+                                )
+
+                                expected = self.np_fn(A, B)
+                                ctm_res = self.fhe_fn(ctm_a, ctm_b)
+                                result = ctm_res.decrypt(
+                                    keys.secretKey,
+                                    unpack_type="original",
+                                )
+
+                                self.assertArrayClose(actual=result, expected=expected)
+
+                            except Exception:
+                                self._record_case(
+                                    params={
+                                        "case": "block_matrix_operation",
+                                        "op": self.op_name,
+                                        "size": size,
+                                        "order": order_name,
+                                        "mode": mode,
+                                        "batch_size": batch_size,
+                                        "ringDim": params["ringDim"],
+                                    },
+                                    input_data={"A": A, "B": B},
+                                    expected=expected,
+                                    result=result,
+                                )
+                                raise
+
+                            finally:
+                                del ctm_a, ctm_b, ctm_res, result
+                                gc.collect()
+
+            finally:
+                del cc, keys
+                gc.collect()
+
+
+class TestBlockMatrixAdd(BlockMatrixTestBase, MainUnittest):
+    op_name = "add"
+    min_depth = 2
+
+    def np_fn(self, a, b=None):
+        return a + b
+
+    def fhe_fn(self, a, b=None):
+        return onp.add(a, b)
+
+
+class TestBlockMatrixSubtract(BlockMatrixTestBase, MainUnittest):
+    op_name = "subtract"
+    min_depth = 2
+
+    def np_fn(self, a, b=None):
+        return a - b
+
+    def fhe_fn(self, a, b=None):
+        return onp.subtract(a, b)
+
+
+class TestBlockMatrixMultiply(BlockMatrixTestBase, MainUnittest):
+    op_name = "multiply"
+    min_depth = 4
+    needs_mult_key = True
+
+    def np_fn(self, a, b=None):
+        return a * b
+
+    def fhe_fn(self, a, b=None):
+        return onp.multiply(a, b)
+
+
+class TestBlockMatrixSum(BlockMatrixTestBase, MainUnittest):
+    op_name = "sum"
+    min_depth = 4
+    needs_sum_key = True
+    needs_global_sum_key = True
+
+    def np_fn(self, a, b=None):
+        return np.sum(a)
+
+    def fhe_fn(self, a, b=None):
+        return onp.sum(a)
+
+
+class TestBlockMatrixMean(BlockMatrixTestBase, MainUnittest):
+    op_name = "mean"
+    min_depth = 4
+    needs_mult_key = True
+    needs_sum_key = True
+    needs_global_sum_key = True
+
+    def np_fn(self, a, b=None):
+        return np.mean(a)
+
+    def fhe_fn(self, a, b=None):
+        return onp.mean(a)

--- a/tests/cases/big_matrix/test_block_matvec_mul.py
+++ b/tests/cases/big_matrix/test_block_matvec_mul.py
@@ -5,8 +5,10 @@ import openfhe_numpy as onp
 from core import *
 
 
-SIZES = [5, 8]
-BLOCK_BATCH_SIZE = 4
+# ckks_params_block.csv uses ringDim=512, so the CKKS slot capacity is 256.
+# A 17 x 17 matrix has 289 entries, forcing block packing because 289 > 256.
+SIZES = [17]
+BLOCK_PARAMS_CSV = CRYPTO_PARAMS_DIR / "ckks_params_block.csv"
 
 
 def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
@@ -56,27 +58,13 @@ class BlockMatVecTestBase:
     vector_mode = None
     case_name = None
 
-    def _attach_matvec_keys(self, secret_key, block_matrix):
-        """Attach sum keys to each matrix block for block matvec."""
-        for block in block_matrix.data:
-            if block.order == onp.ROW_MAJOR:
-                block.extra["colkey"] = onp.sum_col_keys(secret_key, block.ncols)
-            elif block.order == onp.COL_MAJOR:
-                block.extra["rowkey"] = onp.sum_row_keys(
-                    secret_key,
-                    block.nrows,
-                    block.batch_size * 4,
-                )
-            else:
-                raise ValueError(f"Unsupported order: {block.order}")
-
     def test_block_matrix_vector_product(self):
-        ckks_params = load_ckks_params()
+        ckks_params = load_ckks_params(BLOCK_PARAMS_CSV)
 
         for p in ckks_params:
             params = _ensure_depth(p, 4)
-            max_batch_size = params["ringDim"] // 2
-            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+            slot_capacity = params["ringDim"] // 2
+            batch_size = slot_capacity
 
             if batch_size <= 0:
                 continue
@@ -87,11 +75,11 @@ class BlockMatVecTestBase:
 
             try:
                 for size in SIZES:
-                    if size > max_batch_size:
-                        continue
-                    size = 5
+                    self.assertGreater(size * size, slot_capacity)
+
                     A = generate_random_array(rows=size, cols=size)
                     b = generate_random_array(rows=size)
+                    expected = A @ b
 
                     result = None
                     ctm = None
@@ -133,13 +121,12 @@ class BlockMatVecTestBase:
                         self.assertArrayClose(actual=result, expected=expected)
 
                     except Exception:
-                        print(A, b, size, batch_size, params["ringDim"])
-                        print(f"expected={expected}")
-                        print(f"result={result}")
                         self._record_case(
                             params={
                                 "case": self.case_name,
                                 "size": size,
+                                "matrix_slots": size * size,
+                                "slot_capacity": slot_capacity,
                                 "batch_size": batch_size,
                                 "ringDim": params["ringDim"],
                             },

--- a/tests/cases/big_matrix/test_block_matvec_mul.py
+++ b/tests/cases/big_matrix/test_block_matvec_mul.py
@@ -1,0 +1,178 @@
+import gc
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+from core import *
+
+
+SIZES = [5, 8]
+BLOCK_BATCH_SIZE = 4
+
+
+def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
+    p = params.copy()
+    if p.get("multiplicativeDepth", 0) < min_depth:
+        p["multiplicativeDepth"] = min_depth
+    return p
+
+
+def _make_block_array(
+    cc,
+    data,
+    batch_size,
+    order,
+    mode,
+    fhe_type,
+    public_key=None,
+    target_cols=None,
+    compact=False,
+):
+    kwargs = {
+        "cc": cc,
+        "data": data,
+        "batch_size": batch_size,
+        "block_shape": None,
+        "order": order,
+        "mode": mode,
+        "fhe_type": fhe_type,
+        "compact": compact,
+    }
+
+    if public_key is not None:
+        kwargs["public_key"] = public_key
+
+    if target_cols is not None:
+        kwargs["target_cols"] = target_cols
+
+    return onp.block_array(**kwargs)
+
+
+class BlockMatVecTestBase:
+    """Base class for block matrix-vector multiplication tests."""
+
+    matrix_order = None
+    vector_order = None
+    matrix_mode = None
+    vector_mode = None
+    case_name = None
+
+    def _attach_matvec_keys(self, secret_key, block_matrix):
+        """Attach sum keys to each matrix block for block matvec."""
+        for block in block_matrix.data:
+            if block.order == onp.ROW_MAJOR:
+                block.extra["colkey"] = onp.sum_col_keys(secret_key, block.ncols)
+            elif block.order == onp.COL_MAJOR:
+                block.extra["rowkey"] = onp.sum_row_keys(
+                    secret_key,
+                    block.nrows,
+                    block.batch_size * 4,
+                )
+            else:
+                raise ValueError(f"Unsupported order: {block.order}")
+
+    def test_block_matrix_vector_product(self):
+        ckks_params = load_ckks_params()
+
+        for p in ckks_params:
+            params = _ensure_depth(p, 4)
+            max_batch_size = params["ringDim"] // 2
+            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+
+            if batch_size <= 0:
+                continue
+
+            cc, keys = gen_crypto_context(params)
+            cc.EvalMultKeyGen(keys.secretKey)
+            cc.EvalSumKeyGen(keys.secretKey)
+
+            try:
+                for size in SIZES:
+                    if size > max_batch_size:
+                        continue
+                    size = 5
+                    A = generate_random_array(rows=size, cols=size)
+                    b = generate_random_array(rows=size)
+
+                    result = None
+                    ctm = None
+                    ctv = None
+                    ctv_result = None
+
+                    try:
+                        ctm = _make_block_array(
+                            cc=cc,
+                            data=A,
+                            batch_size=batch_size,
+                            order=self.matrix_order,
+                            mode=self.matrix_mode,
+                            fhe_type="C",
+                            public_key=keys.publicKey,
+                        )
+
+                        vector_kwargs = {
+                            "cc": cc,
+                            "data": b,
+                            "batch_size": batch_size,
+                            "order": self.vector_order,
+                            "mode": self.vector_mode,
+                            "fhe_type": "C",
+                            "public_key": keys.publicKey,
+                            "compact": True,
+                        }
+
+                        if self.vector_order == onp.ROW_MAJOR:
+                            vector_kwargs["target_cols"] = ctm.get_block(0, 0).nrows
+
+                        ctv = _make_block_array(**vector_kwargs)
+
+                        onp.attach_block_matvec_keys(ctm, keys.secretKey)
+
+                        ctv_result = ctm @ ctv
+                        result = ctv_result.decrypt(keys.secretKey, unpack_type="original")
+
+                        self.assertArrayClose(actual=result, expected=expected)
+
+                    except Exception:
+                        print(A, b, size, batch_size, params["ringDim"])
+                        print(f"expected={expected}")
+                        print(f"result={result}")
+                        self._record_case(
+                            params={
+                                "case": self.case_name,
+                                "size": size,
+                                "batch_size": batch_size,
+                                "ringDim": params["ringDim"],
+                            },
+                            input_data={"A": A, "b": b},
+                            expected=expected,
+                            result=result,
+                        )
+                        raise
+
+                    finally:
+                        del ctm, ctv, ctv_result, result
+                        gc.collect()
+
+            finally:
+                del cc, keys
+                gc.collect()
+
+
+class TestBlockRowMajorColMajorMatVec(BlockMatVecTestBase, MainUnittest):
+    """Block row-major matrix times block column-major vector."""
+
+    matrix_order = onp.ROW_MAJOR
+    vector_order = onp.COL_MAJOR
+    matrix_mode = "zero"
+    vector_mode = "tile"
+    case_name = "block_rowmajor_colmajor_matvec"
+
+
+class TestBlockColMajorRowMajorMatVec(BlockMatVecTestBase, MainUnittest):
+    """Block column-major matrix times block row-major vector."""
+
+    matrix_order = onp.COL_MAJOR
+    vector_order = onp.ROW_MAJOR
+    matrix_mode = "zero"
+    vector_mode = "tile"
+    case_name = "block_colmajor_rowmajor_matvec"

--- a/tests/cases/big_matrix/test_block_vector.py
+++ b/tests/cases/big_matrix/test_block_vector.py
@@ -5,10 +5,12 @@ import openfhe_numpy as onp
 from core import *
 
 
-SIZES = [5, 8]
-BLOCK_BATCH_SIZE = 4
+# ckks_params_block.csv uses ringDim=512, so the CKKS slot capacity is 256.
+# A vector of length 257 forces block packing because 257 > 256.
+SIZES = [257]
 ORDERS = [("row_major", onp.ROW_MAJOR)]
 MODES = ["zero"]
+BLOCK_PARAMS_CSV = CRYPTO_PARAMS_DIR / "ckks_params_block.csv"
 
 
 def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
@@ -61,12 +63,12 @@ class BlockVectorBinaryTestBase:
         if self.__class__ is BlockVectorBinaryTestBase:
             self.skipTest("base class")
 
-        ckks_params = load_ckks_params()
+        ckks_params = load_ckks_params(BLOCK_PARAMS_CSV)
 
         for _, p in enumerate(ckks_params):
             params = _ensure_depth(p, self.min_depth)
-            max_batch_size = params["ringDim"] // 2
-            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+            slot_capacity = params["ringDim"] // 2
+            batch_size = slot_capacity
 
             if batch_size <= 0:
                 continue
@@ -81,8 +83,7 @@ class BlockVectorBinaryTestBase:
 
             try:
                 for size in SIZES:
-                    if size > max_batch_size:
-                        continue
+                    self.assertGreater(size, slot_capacity)
 
                     a = generate_random_array(rows=size)
                     b = generate_random_array(rows=size)
@@ -130,6 +131,8 @@ class BlockVectorBinaryTestBase:
                                         "case": "block_vector_binary",
                                         "op": self.op_name,
                                         "size": size,
+                                        "vector_slots": size,
+                                        "slot_capacity": slot_capacity,
                                         "order": order_name,
                                         "mode": mode,
                                         "batch_size": batch_size,
@@ -162,7 +165,7 @@ class TestBlockVectorAdd(BlockVectorBinaryTestBase, MainUnittest):
 
 
 class TestBlockVectorSubtract(BlockVectorBinaryTestBase, MainUnittest):
-    op_name = "sub"
+    op_name = "subtract"
     min_depth = 2
 
     def np_fn(self, a, b):
@@ -173,7 +176,7 @@ class TestBlockVectorSubtract(BlockVectorBinaryTestBase, MainUnittest):
 
 
 class TestBlockVectorMultiply(BlockVectorBinaryTestBase, MainUnittest):
-    op_name = "mul"
+    op_name = "multiply"
     min_depth = 4
     needs_mult_key = True
 

--- a/tests/cases/big_matrix/test_block_vector.py
+++ b/tests/cases/big_matrix/test_block_vector.py
@@ -1,0 +1,210 @@
+import gc
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+from core import *
+
+
+SIZES = [5, 8]
+BLOCK_BATCH_SIZE = 4
+ORDERS = [("row_major", onp.ROW_MAJOR)]
+MODES = ["zero"]
+
+
+def _ensure_depth(params: dict, min_depth: int = 4) -> dict:
+    p = params.copy()
+    if p.get("multiplicativeDepth", 0) < min_depth:
+        p["multiplicativeDepth"] = min_depth
+    return p
+
+
+def _make_block_vector(
+    cc,
+    data,
+    batch_size,
+    order,
+    mode,
+    fhe_type,
+    public_key=None,
+):
+    kwargs = {
+        "cc": cc,
+        "data": data,
+        "batch_size": batch_size,
+        "block_shape": None,
+        "order": order,
+        "mode": mode,
+        "fhe_type": fhe_type,
+    }
+
+    if fhe_type == "C":
+        kwargs["public_key"] = public_key
+
+    return onp.block_array(**kwargs)
+
+
+class BlockVectorBinaryTestBase:
+    """Base class for one-operation block vector binary tests."""
+
+    op_name = None
+    min_depth = 4
+    needs_mult_key = False
+    needs_sum_key = False
+
+    def np_fn(self, a, b):
+        raise NotImplementedError
+
+    def fhe_fn(self, a, b):
+        raise NotImplementedError
+
+    def test_binary_operation(self):
+        if self.__class__ is BlockVectorBinaryTestBase:
+            self.skipTest("base class")
+
+        ckks_params = load_ckks_params()
+
+        for _, p in enumerate(ckks_params):
+            params = _ensure_depth(p, self.min_depth)
+            max_batch_size = params["ringDim"] // 2
+            batch_size = min(BLOCK_BATCH_SIZE, max_batch_size)
+
+            if batch_size <= 0:
+                continue
+
+            cc, keys = gen_crypto_context(params)
+
+            if self.needs_mult_key:
+                cc.EvalMultKeyGen(keys.secretKey)
+
+            if self.needs_sum_key:
+                cc.EvalSumKeyGen(keys.secretKey)
+
+            try:
+                for size in SIZES:
+                    if size > max_batch_size:
+                        continue
+
+                    a = generate_random_array(rows=size)
+                    b = generate_random_array(rows=size)
+
+                    for order_name, order_value in ORDERS:
+                        expected = self.np_fn(a, b)
+
+                        for mode in MODES:
+                            result = None
+                            ctv_a = None
+                            ctv_b = None
+                            ctv_res = None
+
+                            try:
+                                ctv_a = _make_block_vector(
+                                    cc=cc,
+                                    data=a,
+                                    batch_size=batch_size,
+                                    order=order_value,
+                                    mode=mode,
+                                    fhe_type="C",
+                                    public_key=keys.publicKey,
+                                )
+                                ctv_b = _make_block_vector(
+                                    cc=cc,
+                                    data=b,
+                                    batch_size=batch_size,
+                                    order=order_value,
+                                    mode=mode,
+                                    fhe_type="C",
+                                    public_key=keys.publicKey,
+                                )
+
+                                ctv_res = self.fhe_fn(ctv_a, ctv_b)
+                                result = ctv_res.decrypt(
+                                    keys.secretKey,
+                                    unpack_type="original",
+                                )
+
+                                self.assertArrayClose(actual=result, expected=expected)
+
+                            except Exception:
+                                self._record_case(
+                                    params={
+                                        "case": "block_vector_binary",
+                                        "op": self.op_name,
+                                        "size": size,
+                                        "order": order_name,
+                                        "mode": mode,
+                                        "batch_size": batch_size,
+                                        "ringDim": params["ringDim"],
+                                    },
+                                    input_data={"a": a, "b": b},
+                                    expected=expected,
+                                    result=result,
+                                )
+                                raise
+
+                            finally:
+                                del ctv_a, ctv_b, ctv_res, result
+                                gc.collect()
+
+            finally:
+                del cc, keys
+                gc.collect()
+
+
+class TestBlockVectorAdd(BlockVectorBinaryTestBase, MainUnittest):
+    op_name = "add"
+    min_depth = 2
+
+    def np_fn(self, a, b):
+        return a + b
+
+    def fhe_fn(self, a, b):
+        return onp.add(a, b)
+
+
+class TestBlockVectorSubtract(BlockVectorBinaryTestBase, MainUnittest):
+    op_name = "sub"
+    min_depth = 2
+
+    def np_fn(self, a, b):
+        return a - b
+
+    def fhe_fn(self, a, b):
+        return onp.subtract(a, b)
+
+
+class TestBlockVectorMultiply(BlockVectorBinaryTestBase, MainUnittest):
+    op_name = "mul"
+    min_depth = 4
+    needs_mult_key = True
+
+    def np_fn(self, a, b):
+        return a * b
+
+    def fhe_fn(self, a, b):
+        return onp.multiply(a, b)
+
+
+class TestBlockVectorDot(BlockVectorBinaryTestBase, MainUnittest):
+    op_name = "dot"
+    min_depth = 4
+    needs_mult_key = True
+    needs_sum_key = True
+
+    def np_fn(self, a, b):
+        return np.dot(a, b)
+
+    def fhe_fn(self, a, b):
+        return onp.dot(a, b)
+
+
+class TestBlockVectorMatmul(BlockVectorBinaryTestBase, MainUnittest):
+    op_name = "matmul"
+    min_depth = 4
+    needs_mult_key = True
+    needs_sum_key = True
+
+    def np_fn(self, a, b):
+        return np.dot(a, b)
+
+    def fhe_fn(self, a, b):
+        return a @ b

--- a/tests/cases/matrix_ops/test_matrix_sumcum.py
+++ b/tests/cases/matrix_ops/test_matrix_sumcum.py
@@ -56,7 +56,7 @@ class TestMatrixCumulativeSumRow(MainUnittest):
                                 else:
                                     onp.gen_accumulate_cols_key(keys.secretKey, ctm.ncols)
 
-                                ctm_result = onp.cumulative_sum(ctm, axis=0)
+                                ctm_result = onp.cumsum(ctm, axis=0)
                                 result = ctm_result.decrypt(keys.secretKey, unpack_type="original")
                                 self.assertArrayClose(actual=result, expected=expected)
                             except Exception:
@@ -119,7 +119,7 @@ class TestMatrixCumulativeSumCol(MainUnittest):
                                 else:
                                     onp.gen_accumulate_rows_key(keys.secretKey, ctm.ncols)
 
-                                ctm_result = onp.cumulative_sum(ctm, axis=1)
+                                ctm_result = onp.cumsum(ctm, axis=1)
                                 result = ctm_result.decrypt(keys.secretKey, unpack_type="original")
                                 self.assertArrayClose(actual=result, expected=expected)
                             except Exception:

--- a/tests/cases/slicing/test_slicing_matrix.py
+++ b/tests/cases/slicing/test_slicing_matrix.py
@@ -18,7 +18,7 @@ OPS = [
 ]
 
 
-def next_power_of_2(n):
+def next_power_of_two(n):
     if n <= 0:
         return 1
     return 1 << (n - 1).bit_length()
@@ -34,8 +34,8 @@ class TestSlicingMatrix(MainUnittest):
 
             try:
                 for rows, cols in SHAPES:
-                    nrow = next_power_of_2(rows)
-                    ncol = next_power_of_2(cols)
+                    nrow = onp.next_power_of_two(rows)
+                    ncol = onp.next_power_of_two(cols)
                     nelements = nrow * ncol
 
                     if nelements > batch_size:

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,5 +1,5 @@
 from .utils import generate_random_array
-from .crypto_context import load_ckks_params, gen_crypto_context
+from .crypto_context import load_ckks_params, gen_crypto_context, CRYPTO_PARAMS_DIR
 from .case import MainUnittest
 from .runner import QuietRunner
 from .result import MainTextTestResult
@@ -13,4 +13,5 @@ __all__ = [
     "generate_random_array",
     "load_ckks_params",
     "gen_crypto_context",
+    "CRYPTO_PARAMS_DIR",
 ]

--- a/tests/core/crypto_context.py
+++ b/tests/core/crypto_context.py
@@ -116,23 +116,35 @@ KEY_SWITCH_TECHNIQUE_MAP: Dict[str, Any] = {
 # ==============================================================================
 
 
-def load_ckks_params() -> List[Dict[str, Any]]:
-    """
-    Load and parse CKKS parameter sets from CSV file.
+def load_ckks_params(path: Path | str | None = None) -> List[Dict[str, Any]]:
+    """Load and parse CKKS parameter sets from a CSV file.
 
-    Returns:
-        List of parameter dictionaries with converted types.
+    Parameters
+    ----------
+    path : Path | str | None, default=None
+        CSV file to load. If ``None``, uses ``PARAMS_CSV``.
 
-    Raises:
-        FileNotFoundError: If the CSV file is not found.
-        ValueError: If parameter conversion fails.
+    Returns
+    -------
+    list[dict[str, Any]]
+        Parameter dictionaries with converted types.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the CSV file is not found.
+    ValueError
+        If parameter conversion fails.
     """
-    if not PARAMS_CSV.exists():
-        raise FileNotFoundError(f"Missing CSV file: {PARAMS_CSV}")
+    print("path = ", path)
+    csv_path = PARAMS_CSV if path is None else Path(path)
+
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Missing CSV file: {csv_path}")
 
     params_list: List[Dict[str, Any]] = []
 
-    with PARAMS_CSV.open(newline="") as csvfile:
+    with csv_path.open(newline="") as csvfile:
         reader = csv.DictReader(csvfile)
 
         for row_num, row in enumerate(reader, start=1):
@@ -143,9 +155,7 @@ def load_ckks_params() -> List[Dict[str, Any]]:
                 try:
                     entry[key] = converter(val)
                 except ValueError as e:
-                    raise ValueError(
-                        f"Error parsing '{key}' at row {row_num}: {e}"
-                    ) from e
+                    raise ValueError(f"Error parsing '{key}' at row {row_num}: {e}") from e
 
             params_list.append(entry)
 
@@ -210,9 +220,7 @@ def gen_crypto_context(params: Dict[str, Any]) -> Tuple[Any, Any]:
     return cc, keys
 
 
-def get_cached_crypto_context(
-    params: Dict[str, Any], use_cache: bool = True
-) -> Tuple[Any, Any]:
+def get_cached_crypto_context(params: Dict[str, Any], use_cache: bool = True) -> Tuple[Any, Any]:
     """
     Get a cached CryptoContext or generate a new one.
 

--- a/tests/core/crypto_params/ckks_params_block.csv
+++ b/tests/core/crypto_params/ckks_params_block.csv
@@ -1,0 +1,2 @@
+ptModulus,digitSize,standardDeviation,secretKeyDist,maxRelinSkDeg,ksTech,scalTech,firstModSize,batchSize,numLargeDigits,multiplicativeDepth,scalingModSize,securityLevel,ringDim
+0,0,3.19,UNIFORM_TERNARY,2,HYBRID,FIXEDAUTO,60,256,3,4,59,HEStd_NotSet,512

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -158,6 +158,11 @@ def get_test_from_module(module_name: str) -> List[str]:
             if isinstance(t, unittest.TestSuite):
                 walk(t)
             else:
+                if t.__class__.__name__ == "_FailedTest":
+                    raise RuntimeError(
+                        f"Failed to import/discover tests for module '{module_name}'. "
+                        f"Run: python3 -m unittest -v {module_name}"
+                    )
                 ids.append(t.id())
 
     walk(suite)
@@ -515,7 +520,7 @@ def main() -> None:
     if all_failed:
         print("\n  Unsuccessful tests:")
         for label in all_failed:
-            print(f"    ✗ {label}")
+            print(f"    x {label}")
 
     print(f"\n  Total wall time:     {test_time:.2f}s")
     print(f"  Total CPU time:      {_fmt_cpu(total_cpu_time, test_time)}")


### PR DESCRIPTION
## Purpose

Issue: #56 

This PR adds block matrix arithmetic support on top of the block tensor classes and constructors.

It enables large matrices and vectors to be split into encoded blocks when the logical input requires more slots than one ciphertext can provide.

## Scope

1. This PR adds block support for:

* `+` / `add`;
* `-` / `subtract`;
* `*` / elementwise multiply;
* matrix-vector multiplication, `matrix @ vector`;
* matrix-matrix multiplication, `matrix @ matrix`;
* negation;
* transpose;
* cumulative sum;
* sum.

2. Rename `cumulative_sum` to `cumsum` for NumPy API compatibility.
3. Rename `pow` to `power` for NumPy API compatibility.
4. Add simple tests for block vector, block matrix, and block matrix-vector operations.
5. Move auxiliary arithmetic helpers to `arithmetic_utils.py`.
6. Move block arithmetic logic and helpers to `block_arithmetic.py` and `block_arithmetic_utils.py`.

## Out of scope

This PR does not change the block tensor class design or block tensor constructors. Those are handled in earlier PRs.

This PR also does not add full NumPy slicing, broadcasting, or general block reshaping support.

## Validation

Added and ran simple block arithmetic tests covering:

* block vector arithmetic;
* block matrix arithmetic;
* block matrix-vector multiplication;
* oversized matrix/vector inputs that require block packing.

