### PR TITLE
Add examples for block tensor operations

### DIFF
--- a/examples/python/block_tensor/simple_block_apply_chebyshev.py
+++ b/examples/python/block_tensor/simple_block_apply_chebyshev.py
@@ -1,0 +1,150 @@
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+
+
+def sigmoid(x):
+    """Logistic sigmoid, evaluated by the Chebyshev approximation below."""
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def validate_and_print_results(computed, expected, operation_name, eps):
+    """Validate an approximate (Chebyshev) result against the plaintext reference."""
+    print("\n" + "*" * 60)
+    print(f"* {operation_name}")
+    print("*" * 60)
+    print(f"\nExpected:\n{expected}")
+    print(f"\nDecrypted Result:\n{computed}")
+
+    is_match, error = onp.check_equality(computed, expected, eps)
+    print(f"\nMatch (tol={eps}): {is_match}, Total Error: {error}")
+    return is_match, error
+
+
+def print_block_metadata(name, block_array):
+    """Print block tensor metadata."""
+    print(f"\n{name} metadata")
+    print(f"  original_shape : {block_array.original_shape}")
+    print(f"  padded shape   : {block_array.shape}")
+    print(f"  block_shape    : {block_array.block_shape}")
+    print(f"  grid_shape     : {block_array.grid_shape}")
+    print(f"  num_blocks     : {block_array.num_blocks}")
+    print(f"  batch_size     : {block_array.batch_size}")
+
+
+def main():
+    """
+    Apply an arbitrary ciphertext-level function to every block with ``apply``.
+
+    ``BlockCTArray.apply(func, ...)`` runs ``func`` on each block's underlying
+    ciphertext and rewraps the results with the original block metadata, so any
+    OpenFHE ciphertext-to-ciphertext routine can be evaluated element-wise across
+    a tiled tensor.
+
+    This example evaluates smooth activation functions homomorphically via
+    Chebyshev approximation:
+      - sigmoid over an 8x8 block matrix (a 2x2 grid of ciphertext blocks)
+      - tanh over a 40-entry block vector (5 ciphertext blocks)
+
+    ``cc.EvalChebyshevFunction(func, ct, a, b, degree)`` fits ``func`` on the
+    interval ``[a, b]`` with a degree-``degree`` polynomial and evaluates it on
+    the ciphertext. It takes the ciphertext as its second argument, so it is
+    wrapped in a lambda for ``apply`` (which passes the ciphertext first). The
+    result is a polynomial approximation, so it is compared with a looser
+    tolerance than the exact block operations.
+    """
+
+    # --- Cryptographic setup -------------------------------------------------
+    ring_dim = 2**12  # 4096
+    mult_depth = 8  # degree-13 Chebyshev evaluation
+    scale_mod_size = 50
+
+    params = CCParamsCKKSRNS()
+    params.SetRingDim(ring_dim)
+    params.SetSecurityLevel(HEStd_NotSet)
+    params.SetMultiplicativeDepth(mult_depth)
+    params.SetScalingModSize(scale_mod_size)
+    params.SetFirstModSize(60)
+    params.SetScalingTechnique(FIXEDAUTO)
+
+    cc = GenCryptoContext(params)
+    cc.Enable(PKESchemeFeature.PKE)
+    cc.Enable(PKESchemeFeature.LEVELEDSHE)
+    cc.Enable(PKESchemeFeature.ADVANCEDSHE)
+
+    keys = cc.KeyGen()
+    cc.EvalMultKeyGen(keys.secretKey)  # Chebyshev needs the relinearization key
+
+    batch_size = cc.GetRingDimension() // 2
+
+    # --- Chebyshev approximation settings ------------------------------------
+    # Inputs lie in [-3, 3]; approximate over the slightly wider [-4, 4].
+    lower_bound, upper_bound = -4.0, 4.0
+    poly_degree = 13
+    tol = 1e-2  # approximation tolerance (exact block ops match far tighter)
+
+    # --- Inputs --------------------------------------------------------------
+    matrix = np.linspace(-3.0, 3.0, 64).reshape(8, 8)
+    vector = np.linspace(-3.0, 3.0, 40)
+
+    print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
+    print(f"Slots per ciphertext: {batch_size}")
+    print(f"Matrix shape        : {matrix.shape}  ({matrix.size} entries)")
+    print(f"Vector shape        : {vector.shape}  ({vector.size} entries)")
+
+    # --- Build encrypted block tensors ---------------------------------------
+    # Explicit block_shape forces a multi-block grid so apply runs over several
+    # ciphertext blocks rather than one.
+    ctm = onp.block_array(
+        cc=cc,
+        data=matrix,
+        batch_size=batch_size,
+        block_shape=(4, 4),
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+    ctv = onp.block_array(
+        cc=cc,
+        data=vector,
+        batch_size=batch_size,
+        block_shape=(8,),
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+
+    print_block_metadata("Encrypted block matrix", ctm)
+    print_block_metadata("Encrypted block vector", ctv)
+
+    all_ok = True
+
+    # 1) Sigmoid over every block of the matrix.
+    # apply passes the block ciphertext first, so wrap EvalChebyshevFunction
+    # (which expects the ciphertext second) in a lambda.
+    res_matrix = ctm.apply(
+        lambda ct: cc.EvalChebyshevFunction(sigmoid, ct, lower_bound, upper_bound, poly_degree)
+    ).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res_matrix, sigmoid(matrix), "Block matrix sigmoid via apply", tol
+    )
+    all_ok = all_ok and is_match
+
+    # 2) tanh over every block of the vector.
+    res_vector = ctv.apply(
+        lambda ct: cc.EvalChebyshevFunction(np.tanh, ct, lower_bound, upper_bound, poly_degree)
+    ).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res_vector, np.tanh(vector), "Block vector tanh via apply", tol
+    )
+    all_ok = all_ok and is_match
+
+    print("\n" + "=" * 60)
+    print(f"All checks passed: {all_ok}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/block_tensor/simple_block_matrix_broadcast.py
+++ b/examples/python/block_tensor/simple_block_matrix_broadcast.py
@@ -1,0 +1,147 @@
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+
+
+def validate_and_print_results(computed, expected, operation_name):
+    """Helper function to validate and print matrix results."""
+    print("\n" + "*" * 60)
+    print(f"* {operation_name}")
+    print("*" * 60)
+    print(f"\nExpected:\n{expected}")
+    print(f"\nDecrypted Result:\n{computed}")
+
+    is_match, error = onp.check_equality(computed, expected)
+    print(f"\nMatch: {is_match}, Total Error: {error}")
+    return is_match, error
+
+
+def main():
+    """
+    Broadcasting for block matrices.
+
+    A block matrix is a logical matrix tiled into a grid of ciphertext blocks
+    because it is too large to pack into a single ciphertext. This example adds a
+    vector to every row and to every column of such a matrix -- the encrypted
+    analogue of NumPy broadcasting:
+
+        (m, n) + (n,)    -> add the row vector to each row
+        (m, n) + (m, 1)  -> add the column vector to each column
+
+    Key points for block broadcasting:
+      1. The vector operand must be tiled so its shared axis lines up with the
+         matrix blocks. Pass block_shape=(block_cols,) for a row vector and
+         block_shape=(block_rows, 1) for a column vector, reading block_cols /
+         block_rows from the matrix's ``block_shape``.
+      2. Each source block is expanded into a matrix block with rotations, so the
+         required rotation keys must be generated first via
+         ``generate_block_broadcast_key``.
+    """
+
+    # --- Cryptographic setup -------------------------------------------------
+    ring_dim = 2**7  # 128
+    mult_depth = 3  # broadcast mask + one element-wise multiply
+    scale_mod_size = 50
+
+    params = CCParamsCKKSRNS()
+    params.SetRingDim(ring_dim)
+    params.SetSecurityLevel(HEStd_NotSet)
+    params.SetMultiplicativeDepth(mult_depth)
+    params.SetScalingModSize(scale_mod_size)
+    params.SetFirstModSize(60)
+    params.SetScalingTechnique(FIXEDAUTO)
+
+    cc = GenCryptoContext(params)
+    cc.Enable(PKESchemeFeature.PKE)
+    cc.Enable(PKESchemeFeature.LEVELEDSHE)
+    cc.Enable(PKESchemeFeature.ADVANCEDSHE)
+
+    keys = cc.KeyGen()
+    cc.EvalMultKeyGen(keys.secretKey)
+    cc.EvalSumKeyGen(keys.secretKey)
+
+    batch_size = cc.GetRingDimension() // 2
+
+    # --- Inputs --------------------------------------------------------------
+    # A 12x12 matrix needs 144 entries > 64 slots, so it is tiled into a 2x2 grid
+    # of (8, 8) blocks. The vectors are aligned to that block layout below.
+    rows, cols = 12, 12
+    matrix = np.arange(1, rows * cols + 1, dtype=float).reshape(rows, cols)
+    row_vector = np.arange(1, cols + 1, dtype=float)  # shape (n,)
+    col_vector = np.arange(1, rows + 1, dtype=float).reshape(rows, 1)  # shape (m, 1)
+
+    print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
+    print(f"Slots per ciphertext: {batch_size}")
+    print(f"Matrix shape        : {matrix.shape}  ({matrix.size} entries)")
+
+    # --- Build the encrypted block matrix ------------------------------------
+    ctm = onp.block_array(
+        cc=cc,
+        data=matrix,
+        batch_size=batch_size,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+    block_rows, block_cols = ctm.block_shape
+    print(
+        f"\nAuto-selected block_shape = {ctm.block_shape}, "
+        f"grid_shape = {ctm.grid_shape}  ({ctm.num_blocks} ciphertext blocks)"
+    )
+
+    # Tile the vectors so their shared axis aligns with the matrix blocks.
+    ctv_row = onp.block_array(
+        cc=cc,
+        data=row_vector,
+        batch_size=batch_size,
+        block_shape=(block_cols,),
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+    ctv_col = onp.block_array(
+        cc=cc,
+        data=col_vector,
+        batch_size=batch_size,
+        block_shape=(block_rows, 1),
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+
+    # Rotation keys for the per-block expansion (both row and column directions).
+    onp.generate_block_broadcast_key(keys.secretKey, ctm)
+
+    all_ok = True
+
+    # 1) Add a row vector to every row: (m, n) + (n,)
+    res = (ctm + ctv_row).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res, matrix + row_vector, "Row broadcast add: matrix (m, n) + vector (n,)"
+    )
+    all_ok = all_ok and is_match
+
+    # 2) Add a column vector to every column: (m, n) + (m, 1)
+    res = (ctm + ctv_col).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res, matrix + col_vector, "Column broadcast add: matrix (m, n) + column (m, 1)"
+    )
+    all_ok = all_ok and is_match
+
+    # 3) Multiply every row by a row vector (element-wise): (m, n) * (n,)
+    res = (ctm * ctv_row).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res, matrix * row_vector, "Row broadcast multiply: matrix (m, n) * vector (n,)"
+    )
+    all_ok = all_ok and is_match
+
+    print("\n" + "=" * 60)
+    print(f"All checks passed: {all_ok}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/block_tensor/simple_block_matrix_cumsum.py
+++ b/examples/python/block_tensor/simple_block_matrix_cumsum.py
@@ -1,0 +1,161 @@
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+
+
+def validate_and_print_results(computed, expected, operation_name):
+    """Helper function to validate and print cumulative-sum results."""
+    print("\n" + "*" * 60)
+    print(f"* {operation_name}")
+    print("*" * 60)
+    print(f"\nExpected:\n{expected}")
+    print(f"\nDecrypted Result:\n{computed}")
+
+    is_match, error = onp.check_equality(computed, expected)
+    print(f"\nMatch: {is_match}, Total Error: {error}")
+    return is_match, error
+
+
+def print_block_metadata(name, block_array):
+    """Print block tensor metadata."""
+    print(f"\n{name} metadata")
+    print(f"  original_shape : {block_array.original_shape}")
+    print(f"  padded shape   : {block_array.shape}")
+    print(f"  block_shape    : {block_array.block_shape}")
+    print(f"  grid_shape     : {block_array.grid_shape}")
+    print(f"  num_blocks     : {block_array.num_blocks}")
+    print(f"  batch_size     : {block_array.batch_size}")
+
+
+def main():
+    """
+    Demonstrate homomorphic cumulative sums on encrypted block tensors.
+
+    Operations shown:
+      - 1-D cumulative sum across multiple ciphertext blocks
+      - 2-D row-wise cumulative sum along axis=1
+
+    For a 1-D block vector, the total from each block is carried into the next
+    block.
+
+    For a 2-D block matrix, the cumulative axis must currently stay inside each
+    block. The matrix below has grid_shape=(4, 1), so axis=1 is supported because
+    there is only one block column. axis=0 would cross block rows and is not yet
+    supported.
+    """
+
+    # --- Cryptographic setup -------------------------------------------------
+    ring_dim = 2**6  # 64
+    mult_depth = 12
+    scale_mod_size = 50
+
+    params = CCParamsCKKSRNS()
+    params.SetRingDim(ring_dim)
+    params.SetSecurityLevel(HEStd_NotSet)
+    params.SetMultiplicativeDepth(mult_depth)
+    params.SetScalingModSize(scale_mod_size)
+    params.SetFirstModSize(60)
+    params.SetScalingTechnique(FIXEDAUTO)
+
+    cc = GenCryptoContext(params)
+    cc.Enable(PKESchemeFeature.PKE)
+    cc.Enable(PKESchemeFeature.LEVELEDSHE)
+    cc.Enable(PKESchemeFeature.ADVANCEDSHE)
+
+    keys = cc.KeyGen()
+    cc.EvalMultKeyGen(keys.secretKey)
+
+    batch_size = cc.GetRingDimension() // 2
+
+    # --- Inputs --------------------------------------------------------------
+    # Both inputs contain more entries than one ciphertext can hold.
+    vector = np.arange(1, 41, dtype=float)
+    matrix = np.arange(1, 65, dtype=float).reshape(16, 4)
+
+    print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
+    print(f"Slots per ciphertext: {batch_size}")
+    print(f"Vector shape        : {vector.shape}  ({vector.size} entries)")
+    print(f"Matrix shape        : {matrix.shape}  ({matrix.size} entries)")
+    print(
+        f"\nThe vector has {vector.size} entries and the matrix has "
+        f"{matrix.size} entries, both exceeding the {batch_size} available slots.\n"
+        "They must therefore be represented using multiple ciphertext blocks."
+    )
+
+    print("\nInput vector:")
+    print(vector)
+    print("\nInput matrix:")
+    print(matrix)
+
+    # --- Build encrypted block tensors ---------------------------------------
+    # Cumsum depth grows with the local block length. Using blocks of length 8
+    # keeps the required depth manageable and produces five ciphertext blocks.
+    vector_block_shape = (8,)
+
+    ctv = onp.block_array(
+        cc=cc,
+        data=vector,
+        batch_size=batch_size,
+        block_shape=vector_block_shape,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+
+    # Auto-selection gives block_shape=(4, 4) and grid_shape=(4, 1).
+    ctm = onp.block_array(
+        cc=cc,
+        data=matrix,
+        batch_size=batch_size,
+        block_shape=None,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+
+    # The 1-D path uses EvalSum to obtain each block's total.
+    onp.gen_sum_key(keys.secretKey)
+
+    # Generate the rotation keys needed by cumulative sums inside each block.
+    onp.gen_accumulate_cols_key(keys.secretKey, ctv.block_shape[0])
+    onp.gen_accumulate_cols_key(keys.secretKey, ctm.block_shape[1])
+
+    print_block_metadata("Encrypted block vector", ctv)
+    print_block_metadata("Encrypted block matrix", ctm)
+
+    all_ok = True
+
+    # 1) Cumsum across all ciphertext blocks of the vector.
+    res_vector = onp.cumsum(ctv).decrypt(
+        keys.secretKey,
+        unpack_type="original",
+    )
+    is_match, _ = validate_and_print_results(
+        res_vector,
+        np.cumsum(vector),
+        "Block vector cumulative sum",
+    )
+    all_ok = all_ok and is_match
+
+    # 2) Row-wise matrix cumsum.
+    # grid_shape[1] == 1, so axis=1 never crosses a block boundary.
+    res_matrix = onp.cumsum(ctm, axis=1).decrypt(
+        keys.secretKey,
+        unpack_type="original",
+    )
+    is_match, _ = validate_and_print_results(
+        res_matrix,
+        np.cumsum(matrix, axis=1),
+        "Block matrix cumulative sum (axis=1)",
+    )
+    all_ok = all_ok and is_match
+
+    print("\n" + "=" * 60)
+    print(f"All checks passed: {all_ok}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/block_tensor/simple_block_power.py
+++ b/examples/python/block_tensor/simple_block_power.py
@@ -1,0 +1,98 @@
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+
+
+def validate_and_print_results(computed, expected, operation_name):
+    """Helper function to validate and print matrix results."""
+    print("\n" + "*" * 60)
+    print(f"* {operation_name}")
+    print("*" * 60)
+    print(f"\nExpected:\n{expected}")
+    print(f"\nDecrypted Result:\n{computed}")
+
+    is_match, error = onp.check_equality(computed, expected)
+    print(f"\nMatch: {is_match}, Total Error: {error}")
+    return is_match, error
+
+
+def print_block_metadata(name, block_array):
+    """Print block tensor metadata."""
+    print(f"\n{name} metadata")
+    print(f"  original_shape : {block_array.original_shape}")
+    print(f"  padded shape   : {block_array.shape}")
+    print(f"  block_shape    : {block_array.block_shape}")
+    print(f"  grid_shape     : {block_array.grid_shape}")
+    print(f"  num_blocks     : {block_array.num_blocks}")
+    print(f"  batch_size     : {block_array.batch_size}")
+
+
+def main():
+    """
+    Element-wise integer power of an encrypted block tensor.
+
+    ``A ** k`` raises every entry to the integer power ``k`` by repeated
+    homomorphic multiplication, applied independently to each ciphertext block.
+    It works for any block shape (no square or grid constraint).
+
+    The multiplicative depth required is ceil(log2(k)); k=3 needs depth 2.
+    """
+
+    # --- Cryptographic setup -------------------------------------------------
+    ring_dim = 2**6  # 64
+    mult_depth = 4  # ceil(log2(k)) for k=3 is 2, plus headroom
+    scale_mod_size = 50
+
+    params = CCParamsCKKSRNS()
+    params.SetRingDim(ring_dim)
+    params.SetSecurityLevel(HEStd_NotSet)
+    params.SetMultiplicativeDepth(mult_depth)
+    params.SetScalingModSize(scale_mod_size)
+    params.SetFirstModSize(60)
+    params.SetScalingTechnique(FIXEDAUTO)
+
+    cc = GenCryptoContext(params)
+    cc.Enable(PKESchemeFeature.PKE)
+    cc.Enable(PKESchemeFeature.LEVELEDSHE)
+    cc.Enable(PKESchemeFeature.ADVANCEDSHE)
+
+    keys = cc.KeyGen()
+    cc.EvalMultKeyGen(keys.secretKey)
+
+    batch_size = cc.GetRingDimension() // 2
+
+    # --- Inputs --------------------------------------------------------------
+    # 64 entries > 32 slots, so the matrix is tiled into a 2x2 grid of (4, 4)
+    # blocks. Values are kept small so the cubes stay in a comfortable range.
+    exponent = 3
+    matrix = np.arange(1, 65, dtype=float).reshape(8, 8) / 8.0
+
+    print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
+    print(f"Slots per ciphertext: {batch_size}")
+    print(f"Matrix shape        : {matrix.shape}  ({matrix.size} entries)")
+    print(f"Exponent            : {exponent}")
+
+    ctm = onp.block_array(
+        cc=cc,
+        data=matrix,
+        batch_size=batch_size,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+    print_block_metadata("Encrypted block matrix", ctm)
+
+    # A ** exponent, element-wise across every block.
+    res = (ctm**exponent).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res, matrix**exponent, f"Block matrix element-wise power (A ** {exponent})"
+    )
+
+    print("\n" + "=" * 60)
+    print(f"All checks passed: {is_match}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/simple_apply_chebyshev.py
+++ b/examples/python/simple_apply_chebyshev.py
@@ -1,0 +1,136 @@
+import numpy as np
+from openfhe import *
+import openfhe_numpy as onp
+
+
+def sigmoid(x):
+    """Logistic sigmoid, evaluated by the Chebyshev approximation below."""
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def validate_and_print_results(computed, expected, operation_name, eps):
+    """Validate an approximate (Chebyshev) result against the plaintext reference."""
+    print("\n" + "*" * 60)
+    print(f"* {operation_name}")
+    print("*" * 60)
+    print(f"\nExpected:\n{expected}")
+    print(f"\nDecrypted Result:\n{computed}")
+
+    is_match, error = onp.check_equality(computed, expected, eps)
+    print(f"\nMatch (tol={eps}): {is_match}, Total Error: {error}")
+    return is_match, error
+
+
+def main():
+    """
+    Apply an arbitrary ciphertext-level function to a CTArray with ``apply``.
+
+    ``CTArray.apply(func, ...)`` runs ``func`` on the underlying ciphertext and
+    rewraps the result with the original shape/metadata, so any OpenFHE
+    ciphertext-to-ciphertext routine can be evaluated element-wise. Here the whole
+    tensor fits in a single ciphertext (unlike the block-tensor apply example).
+
+    This evaluates smooth activation functions homomorphically via Chebyshev
+    approximation:
+      - sigmoid over a 4x4 matrix
+      - tanh over an 8-entry vector
+
+    ``cc.EvalChebyshevFunction(func, ct, a, b, degree)`` fits ``func`` on the
+    interval ``[a, b]`` with a degree-``degree`` polynomial and evaluates it on
+    the ciphertext. It takes the ciphertext as its second argument, so it is
+    wrapped in a lambda for ``apply`` (which passes the ciphertext first). The
+    result is a polynomial approximation, so it is compared with a looser
+    tolerance than exact operations.
+    """
+
+    # --- Cryptographic setup -------------------------------------------------
+    ring_dim = 2**12  # 4096
+    mult_depth = 8  # degree-13 Chebyshev evaluation
+    scale_mod_size = 50
+
+    params = CCParamsCKKSRNS()
+    params.SetRingDim(ring_dim)
+    params.SetSecurityLevel(HEStd_NotSet)
+    params.SetMultiplicativeDepth(mult_depth)
+    params.SetScalingModSize(scale_mod_size)
+    params.SetFirstModSize(60)
+    params.SetScalingTechnique(FIXEDAUTO)
+
+    cc = GenCryptoContext(params)
+    cc.Enable(PKESchemeFeature.PKE)
+    cc.Enable(PKESchemeFeature.LEVELEDSHE)
+    cc.Enable(PKESchemeFeature.ADVANCEDSHE)
+
+    keys = cc.KeyGen()
+    cc.EvalMultKeyGen(keys.secretKey)  # Chebyshev needs the relinearization key
+
+    batch_size = cc.GetRingDimension() // 2
+
+    # --- Chebyshev approximation settings ------------------------------------
+    # Inputs lie in [-3, 3]; approximate over the slightly wider [-4, 4].
+    lower_bound, upper_bound = -4.0, 4.0
+    poly_degree = 13
+    tol = 1e-2  # approximation tolerance (exact ops match far tighter)
+
+    # --- Inputs --------------------------------------------------------------
+    matrix = np.linspace(-3.0, 3.0, 16).reshape(4, 4)
+    vector = np.linspace(-3.0, 3.0, 8)
+
+    print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
+    print(f"Slots per ciphertext: {batch_size}")
+    print(f"Matrix shape        : {matrix.shape}")
+    print(f"Vector shape        : {vector.shape}")
+
+    # Each tensor fits in one ciphertext, so onp.array gives a plain CTArray.
+    ctm = onp.array(
+        cc=cc,
+        data=matrix,
+        batch_size=batch_size,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+    ctv = onp.array(
+        cc=cc,
+        data=vector,
+        batch_size=batch_size,
+        order=onp.ROW_MAJOR,
+        mode="zero",
+        fhe_type="C",
+        public_key=keys.publicKey,
+    )
+
+    all_ok = True
+
+    # 1) Sigmoid over the matrix ciphertext.
+    # apply passes the ciphertext first, so wrap EvalChebyshevFunction
+    # (which expects the ciphertext second) in a lambda.
+    res_matrix = ctm.apply(
+        lambda ct: cc.EvalChebyshevFunction(
+            sigmoid, ct, lower_bound, upper_bound, poly_degree
+        )
+    ).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res_matrix, sigmoid(matrix), "Matrix sigmoid via apply", tol
+    )
+    all_ok = all_ok and is_match
+
+    # 2) tanh over the vector ciphertext.
+    res_vector = ctv.apply(
+        lambda ct: cc.EvalChebyshevFunction(
+            np.tanh, ct, lower_bound, upper_bound, poly_degree
+        )
+    ).decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(
+        res_vector, np.tanh(vector), "Vector tanh via apply", tol
+    )
+    all_ok = all_ok and is_match
+
+    print("\n" + "=" * 60)
+    print(f"All checks passed: {all_ok}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add examples for block tensor arithmetic

The `examples/python/block_tensor/` folder demonstrates block  arithmetic, but a few registered operations still have no example. 

### Block arithmetic operations and current coverage

| Operation | API | Example |
|---|---|---|
| add / subtract / multiply (element-wise + scalar) | `A + B`, `A - B`, `A * B`, `A + s` | `simple_block_matrix_operation.py`, `simple_block_vector_operations.py` |
| broadcasting (row/column vector) | `A + v`, `A * v` | `simple_block_matrix_broadcast.py` |
| matmul — matrix @ vector | `A @ x` | `simple_block_matrix_vector_product.py` |
| matmul — matrix @ matrix (square) | `A @ B` | `simple_square_bmatrix_product.py` |
| dot — vector @ vector | `x @ y`, `onp.dot` | `simple_block_vector_operations.py` |
| cumsum | `onp.cumsum(A, axis)` | `simple_block_matrix_cumsum.py` |
| apply — element-wise function (e.g. Chebyshev) | `A.apply(fn)` | `simple_block_apply_chebyshev.py` |
| power — element-wise | `A ** k` | `simple_block_power.py` |
| transpose | `A.T` | `simple_block_transpose.py` |
| sum / mean — axis reductions | `onp.sum(A, axis)`, `onp.mean(A, axis)` | `simple_block_reductions.py` |
| cumulative_reduce | `A.cumulative_reduce(axis)` | missing |
| roll | `onp.roll(...)` | not implemented in library (skip) |

### Examples to implement

- [x] `simple_block_power.py` — element-wise `A ** k`
- [x] `simple_block_transpose.py` — `A.T` (transpose each block + swap the grid)
- [x] `simple_block_reductions.py` — `sum` / `mean` over `axis=None/0/1` (requires `onp.attach_block_sum_keys`)
- [ ] `simple_block_cumulative_reduce.py` — `cumulative_reduce(axis)` (requires `onp.gen_accumulate_rows_key` / `gen_accumulate_cols_key`)






