### PR TITLE
 Revise block tensor examples

### DIFF
--- a/examples/python/block_tensor/simple_block_matrix_broadcast.py
+++ b/examples/python/block_tensor/simple_block_matrix_broadcast.py
@@ -11,7 +11,7 @@ def validate_and_print_results(computed, expected, operation_name):
     print(f"\nExpected:\n{expected}")
     print(f"\nDecrypted Result:\n{computed}")
 
-    is_match, error = onp.check_equality(computed, expected)
+    is_match, error = onp.check_equality(computed, expected, eps=1e-6)
     print(f"\nMatch: {is_match}, Total Error: {error}")
     return is_match, error
 
@@ -20,7 +20,7 @@ def main():
     """
     Broadcasting for block matrices.
 
-    A block matrix is a logical matrix tiled into a grid of ciphertext blocks
+    A block matrix is a logical matrix partitioned into ciphertext blocks
     because it is too large to pack into a single ciphertext. This example adds a
     vector to every row and to every column of such a matrix -- the encrypted
     analogue of NumPy broadcasting:
@@ -29,8 +29,8 @@ def main():
         (m, n) + (m, 1)  -> add the column vector to each column
 
     Key points for block broadcasting:
-      1. The vector operand must be tiled so its shared axis lines up with the
-         matrix blocks. Pass block_shape=(block_cols,) for a row vector and
+      1. The vector operand must use blocks that line up with the matrix blocks.
+         Pass block_shape=(block_cols,) for a row vector and
          block_shape=(block_rows, 1) for a column vector, reading block_cols /
          block_rows from the matrix's ``block_shape``.
       2. Each source block is expanded into a matrix block with rotations, so the
@@ -39,6 +39,8 @@ def main():
     """
 
     # --- Cryptographic setup -------------------------------------------------
+    # These small parameters keep the tutorial fast. They are not secure and
+    # must not be used in production.
     ring_dim = 2**7  # 128
     mult_depth = 3  # broadcast mask + one element-wise multiply
     scale_mod_size = 50
@@ -57,18 +59,19 @@ def main():
     cc.Enable(PKESchemeFeature.ADVANCEDSHE)
 
     keys = cc.KeyGen()
+    # Broadcasting uses plaintext masks, and the multiplication example also
+    # multiplies two ciphertexts.
     cc.EvalMultKeyGen(keys.secretKey)
-    cc.EvalSumKeyGen(keys.secretKey)
 
-    batch_size = cc.GetRingDimension() // 2
+    batch_size = cc.GetBatchSize()
 
     # --- Inputs --------------------------------------------------------------
-    # A 12x12 matrix needs 144 entries > 64 slots, so it is tiled into a 2x2 grid
-    # of (8, 8) blocks. The vectors are aligned to that block layout below.
-    rows, cols = 12, 12
+    # A 9x9 matrix needs 81 entries > 64 slots, so it is partitioned into a 2x2
+    # grid of (8, 8) blocks. The vectors are aligned to that block layout below.
+    rows, cols = 9, 9
     matrix = np.arange(1, rows * cols + 1, dtype=float).reshape(rows, cols)
     row_vector = np.arange(1, cols + 1, dtype=float)  # shape (n,)
-    col_vector = np.arange(1, rows + 1, dtype=float).reshape(rows, 1)  # shape (m, 1)
+    col_vector = np.arange(1, rows + 1, dtype=float).reshape(rows, 1)
 
     print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
     print(f"Slots per ciphertext: {batch_size}")
@@ -79,6 +82,7 @@ def main():
         cc=cc,
         data=matrix,
         batch_size=batch_size,
+        block_shape=(8, 8),
         order=onp.ROW_MAJOR,
         mode="zero",
         fhe_type="C",
@@ -86,11 +90,11 @@ def main():
     )
     block_rows, block_cols = ctm.block_shape
     print(
-        f"\nAuto-selected block_shape = {ctm.block_shape}, "
+        f"\nBlock shape = {ctm.block_shape}, "
         f"grid_shape = {ctm.grid_shape}  ({ctm.num_blocks} ciphertext blocks)"
     )
 
-    # Tile the vectors so their shared axis aligns with the matrix blocks.
+    # Partition the vectors so their shared axes align with the matrix blocks.
     ctv_row = onp.block_array(
         cc=cc,
         data=row_vector,
@@ -112,7 +116,8 @@ def main():
         public_key=keys.publicKey,
     )
 
-    # Rotation keys for the per-block expansion (both row and column directions).
+    # A single matrix-target call generates the rotation keys needed for both
+    # row and column broadcasting.
     onp.generate_block_broadcast_key(keys.secretKey, ctm)
 
     all_ok = True

--- a/examples/python/block_tensor/simple_block_matrix_cumsum.py
+++ b/examples/python/block_tensor/simple_block_matrix_cumsum.py
@@ -11,7 +11,7 @@ def validate_and_print_results(computed, expected, operation_name):
     print(f"\nExpected:\n{expected}")
     print(f"\nDecrypted Result:\n{computed}")
 
-    is_match, error = onp.check_equality(computed, expected)
+    is_match, error = onp.check_equality(computed, expected, eps=1e-6)
     print(f"\nMatch: {is_match}, Total Error: {error}")
     return is_match, error
 
@@ -33,18 +33,16 @@ def main():
 
     Operations shown:
       - 1-D cumulative sum across multiple ciphertext blocks
-      - 2-D row-wise cumulative sum along axis=1
+      - 2-D cumulative sum across matrix block rows along axis=0
+      - 2-D cumulative sum across matrix block columns along axis=1
 
-    For a 1-D block vector, the total from each block is carried into the next
-    block.
-
-    For a 2-D block matrix, the cumulative axis must currently stay inside each
-    block. The matrix below has grid_shape=(4, 1), so axis=1 is supported because
-    there is only one block column. axis=0 would cross block rows and is not yet
-    supported.
+    In both cases, the terminal cumulative value from one block is carried into
+    the next block along the cumulative axis.
     """
 
     # --- Cryptographic setup -------------------------------------------------
+    # These small parameters keep the tutorial fast. They are not secure and
+    # must not be used in production.
     ring_dim = 2**6  # 64
     mult_depth = 12
     scale_mod_size = 50
@@ -63,14 +61,15 @@ def main():
     cc.Enable(PKESchemeFeature.ADVANCEDSHE)
 
     keys = cc.KeyGen()
+    # Cumsum uses plaintext masks when carrying totals between blocks.
     cc.EvalMultKeyGen(keys.secretKey)
 
-    batch_size = cc.GetRingDimension() // 2
+    batch_size = cc.GetBatchSize()
 
     # --- Inputs --------------------------------------------------------------
     # Both inputs contain more entries than one ciphertext can hold.
     vector = np.arange(1, 41, dtype=float)
-    matrix = np.arange(1, 65, dtype=float).reshape(16, 4)
+    matrix = np.arange(1, 65, dtype=float).reshape(8, 8)
 
     print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
     print(f"Slots per ciphertext: {batch_size}")
@@ -88,9 +87,8 @@ def main():
     print(matrix)
 
     # --- Build encrypted block tensors ---------------------------------------
-    # Cumsum depth grows with the local block length. Using blocks of length 8
-    # keeps the required depth manageable and produces five ciphertext blocks.
     vector_block_shape = (8,)
+    matrix_block_shape = (4, 4)
 
     ctv = onp.block_array(
         cc=cc,
@@ -103,24 +101,19 @@ def main():
         public_key=keys.publicKey,
     )
 
-    # Auto-selection gives block_shape=(4, 4) and grid_shape=(4, 1).
     ctm = onp.block_array(
         cc=cc,
         data=matrix,
         batch_size=batch_size,
-        block_shape=None,
+        block_shape=matrix_block_shape,
         order=onp.ROW_MAJOR,
         mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
     )
 
-    # The 1-D path uses EvalSum to obtain each block's total.
-    onp.gen_sum_key(keys.secretKey)
-
-    # Generate the rotation keys needed by cumulative sums inside each block.
-    onp.gen_accumulate_cols_key(keys.secretKey, ctv.block_shape[0])
-    onp.gen_accumulate_cols_key(keys.secretKey, ctm.block_shape[1])
+    onp.attach_block_cumsum_keys(ctv, keys.secretKey)
+    onp.attach_block_cumsum_keys(ctm, keys.secretKey)
 
     print_block_metadata("Encrypted block vector", ctv)
     print_block_metadata("Encrypted block matrix", ctm)
@@ -139,8 +132,21 @@ def main():
     )
     all_ok = all_ok and is_match
 
-    # 2) Row-wise matrix cumsum.
-    # grid_shape[1] == 1, so axis=1 never crosses a block boundary.
+    # 2) Matrix cumsum down each column, across both block rows.
+    # axis=0 means that values accumulate from top to bottom.
+    res_matrix = onp.cumsum(ctm, axis=0).decrypt(
+        keys.secretKey,
+        unpack_type="original",
+    )
+    is_match, _ = validate_and_print_results(
+        res_matrix,
+        np.cumsum(matrix, axis=0),
+        "Block matrix cumulative sum (axis=0)",
+    )
+    all_ok = all_ok and is_match
+
+    # 3) Matrix cumsum across each row, across both block columns.
+    # axis=1 means that values accumulate from left to right.
     res_matrix = onp.cumsum(ctm, axis=1).decrypt(
         keys.secretKey,
         unpack_type="original",

--- a/examples/python/block_tensor/simple_block_matrix_vector_product.py
+++ b/examples/python/block_tensor/simple_block_matrix_vector_product.py
@@ -38,8 +38,8 @@ def main():
 
     The block_shape=(2, 2) splits the matrix across multiple ciphertext
     blocks, each holding a 2x2 sub-matrix in batch_size=4 slots.
-    compact=True on the vector produces the duplicated, square-compatible
-    packing required for block matvec; do NOT use compact for plain
+    replicate=True on the vector produces the duplicated, square-compatible
+    packing required for block matvec; do NOT use replicate for plain
     vector arithmetic (add/sub/dot).
     """
 
@@ -101,9 +101,9 @@ def main():
     #
     #   1 2 3 0 | 4 5 6 0   (two 2x2 blocks packed as [row0|row1])
     #
-    # The vector is encoded with compact=True (duplicated packing):
+    # The vector is encoded with replicate=True (duplicated packing):
     #
-    #   1 1 1 1 | 0 0 0 0   (compact COL_MAJOR block vector)
+    #   1 1 1 1 | 0 0 0 0   (replicated COL_MAJOR block vector)
     #
     # The result lands in ROW_MAJOR order, one entry per row of the matrix.
 
@@ -118,7 +118,7 @@ def main():
         public_key=keys.publicKey,
     )
 
-    # compact=True: produce duplicated block packing required by block matvec.
+    # replicate=True: produce duplicated block packing required by block matvec.
     ctv_cm = onp.block_array(
         cc=cc,
         data=vector,
@@ -128,7 +128,7 @@ def main():
         mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
-        compact=True,
+        replicate=True,
     )
 
     # Attach summation keys to every matrix block before the product.
@@ -136,7 +136,7 @@ def main():
     onp.attach_block_matvec_keys(ctm_rm, keys.secretKey)
 
     print_block_metadata("Block matrix (ROW_MAJOR)", ctm_rm)
-    print_block_metadata("Block vector (COL_MAJOR, compact)", ctv_cm)
+    print_block_metadata("Block vector (COL_MAJOR, replicated)", ctv_cm)
 
     ctv_result_rm = ctm_rm @ ctv_cm
     res_rm = ctv_result_rm.decrypt(keys.secretKey, unpack_type="original")
@@ -152,7 +152,7 @@ def main():
     # =========================================================
     #
     # Column-wise packing interleaves the matrix columns across slots.
-    # The vector uses compact=True (ROW_MAJOR), producing duplicated
+    # The vector uses replicate=True (ROW_MAJOR), producing duplicated
     # per-element blocks compatible with the COL_MAJOR matrix blocks.
     #
     # The result lands in COL_MAJOR order, one entry per row of the matrix.
@@ -168,7 +168,7 @@ def main():
         public_key=keys.publicKey,
     )
 
-    # compact=True: produce duplicated block packing required by block matvec.
+    # replicate=True: produce duplicated block packing required by block matvec.
     ctv_rm = onp.block_array(
         cc=cc,
         data=vector,
@@ -178,7 +178,7 @@ def main():
         mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
-        compact=True,
+        replicate=True,
     )
 
     # Attach summation keys to every matrix block before the product.
@@ -186,7 +186,7 @@ def main():
     onp.attach_block_matvec_keys(ctm_cm, keys.secretKey)
 
     print_block_metadata("Block matrix (COL_MAJOR)", ctm_cm)
-    print_block_metadata("Block vector (ROW_MAJOR, compact)", ctv_rm)
+    print_block_metadata("Block vector (ROW_MAJOR, replicated)", ctv_rm)
 
     ctv_result_cm = ctm_cm @ ctv_rm
     res_cm = ctv_result_cm.decrypt(keys.secretKey, unpack_type="original")


### PR DESCRIPTION
# Revise block tensor examples

## Summary

This PR revises the following block tensor examples:

* `simple_block_matrix_broadcast.py`
* `simple_block_matrix_cumsum.py`
* `simple_block_matrix_vector_product.py`

## Changes

* Improve the example structure and readability.
* Update the examples to use the current block tensor API.
* Clarify the expected inputs and outputs.

## Conclusion

The revised examples provide clearer demonstrations of block tensor broadcasting, cumulative sums, and matrix–vector multiplication.
