### PR TITLE
Fixes #87 by preventing broadcast and scalar arithmetic from polluting unused slots.

### DIFF
--- a/openfhe_numpy/operations/arithmetic_utils.py
+++ b/openfhe_numpy/operations/arithmetic_utils.py
@@ -38,36 +38,25 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
+from openfhe_numpy.openfhe_numpy import ArrayEncodingType
+from openfhe_numpy.operations.broadcast import broadcast_to
 from openfhe_numpy.tensor.tensor import BaseTensor
-from openfhe_numpy.utils.errors import ONPIncompatibleShapeError, ONPValueError, ONPDimensionError
-from openfhe_numpy.utils.packing import _is_row_major, _is_col_major
+from openfhe_numpy.utils.errors import (
+    ONPDimensionError,
+    ONPIncompatibleShapeError,
+    ONPNotImplementedError,
+    ONPValueError,
+    _require,
+)
+from openfhe_numpy.utils.packing import _is_col_major, _is_row_major
+from openfhe_numpy.utils.typecheck import is_numeric_scalar
 
 
 # ------------------------------------------------------------------------------
-# Arithmetic: Convention
+# Result type
 # ------------------------------------------------------------------------------
-def _require(
-    condition: bool,
-    left: Any,
-    right: Any,
-    message: str,
-    *,
-    error_cls: type[Exception] = ONPIncompatibleShapeError,
-) -> None:
-    """Raise ``error_cls`` when ``condition`` is false.
-
-    By default this reports an ``ONPIncompatibleShapeError`` built from ``left``
-    and ``right``. Pass ``error_cls`` (e.g. ``ONPValueError``) for non-shape
-    failures such as batch-size or packing-order mismatches; those are raised
-    with ``message`` only.
-    """
-    if condition:
-        return
-
-    if error_cls is ONPIncompatibleShapeError:
-        raise ONPIncompatibleShapeError(left, right, message)
-
-    raise error_cls(message)
 
 
 def _result_cls(a: BaseTensor, b: BaseTensor | None = None) -> type[BaseTensor]:
@@ -119,6 +108,8 @@ def _get_matvec_key_name(matrix_order: Any) -> str:
 # ------------------------------------------------------------------------------
 # Arithmetic: Numpy axis convention
 # ------------------------------------------------------------------------------
+
+
 def _normalize_axis(axis, ndim: int) -> int:
     """Normalize integer axis.
 
@@ -142,3 +133,364 @@ def _normalize_sum_axis(axis, ndim: int) -> int | None:
         return None
 
     return _normalize_axis(axis, ndim)
+
+
+# ------------------------------------------------------------------------------
+# Element-wise operation dispatch
+# ------------------------------------------------------------------------------
+
+_EVAL_METHODS: dict[str, str] = {
+    "add": "EvalAdd",
+    "subtract": "EvalSub",
+    "multiply": "EvalMult",
+}
+
+
+def _resolve_eval_op(crypto_context, op_name: str):
+    """Resolve an element-wise operation to its OpenFHE evaluator.
+
+    Parameters
+    ----------
+    crypto_context
+        Crypto context that owns the evaluator methods.
+    op_name
+        Supported operation name: ``add``, ``subtract``, or ``multiply``.
+
+    Returns
+    -------
+    Callable
+        Bound OpenFHE evaluator method.
+
+    Raises
+    ------
+    ONPNotImplementedError
+        If ``op_name`` is not supported.
+    """
+    try:
+        method_name = _EVAL_METHODS[op_name]
+    except KeyError:
+        supported = ", ".join(sorted(_EVAL_METHODS))
+        raise ONPNotImplementedError(
+            f"Unsupported element-wise operation {op_name!r}. Supported operations: {supported}."
+        ) from None
+
+    return getattr(crypto_context, method_name)
+
+
+# ------------------------------------------------------------------------------
+# Packed binary operand context and alignment
+# ------------------------------------------------------------------------------
+
+
+def _binary_crypto_context(a, b):
+    """Return the shared crypto context for two packed operands.
+
+    Parameters
+    ----------
+    a, b
+        Packed operands. At least one must be encrypted.
+
+    Returns
+    -------
+    CryptoContext
+        Crypto context shared by every encrypted operand.
+
+    Raises
+    ------
+    ONPValueError
+        If neither operand is encrypted, or encrypted operands use different
+        crypto contexts or key tags.
+    """
+    ciphertexts = [operand.data for operand in (a, b) if operand.is_encrypted]
+
+    if not ciphertexts:
+        raise ONPValueError("Arithmetic requires at least one encrypted operand.")
+
+    context = ciphertexts[0].GetCryptoContext()
+    key_tag = ciphertexts[0].GetKeyTag() if hasattr(ciphertexts[0], "GetKeyTag") else None
+    for ciphertext in ciphertexts[1:]:
+        current_key_tag = ciphertext.GetKeyTag() if hasattr(ciphertext, "GetKeyTag") else None
+        if ciphertext.GetCryptoContext() != context or current_key_tag != key_tag:
+            raise ONPValueError("Operands must use the same crypto context and key tag.")
+
+    return context
+
+
+def _align_binary_operands(a, b):
+    """Validate and broadcast two packed operands to one logical layout.
+
+    Parameters
+    ----------
+    a, b
+        Packed operands for an element-wise operation.
+
+    Returns
+    -------
+    tuple
+        ``(crypto_context, aligned_a, aligned_b)`` with both operands carrying
+        the NumPy broadcast result as their logical shape and matching physical
+        layouts.
+
+    Raises
+    ------
+    ONPIncompatibleShapeError
+        If the logical shapes are not broadcast-compatible.
+    ONPValueError
+        If batch sizes, packing orders, crypto contexts, key tags, or aligned
+        physical frames differ.
+    """
+    source_a = tuple(a.original_shape)
+    source_b = tuple(b.original_shape)
+    try:
+        output_shape = tuple(np.broadcast_shapes(source_a, source_b))
+    except ValueError as exc:
+        raise ONPIncompatibleShapeError(
+            source_a,
+            source_b,
+            f"cannot broadcast {source_a} and {source_b}",
+        ) from exc
+
+    _require(
+        a.batch_size == b.batch_size,
+        (a.batch_size,),
+        (b.batch_size,),
+        "Element-wise arithmetic requires equal batch_size; "
+        f"got {a.batch_size} and {b.batch_size}.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        a.order == b.order,
+        (a.order,),
+        (b.order,),
+        "Element-wise arithmetic requires matching packing order; "
+        f"got {a.order!r} and {b.order!r}.",
+        error_cls=ONPValueError,
+    )
+
+    crypto_context = _binary_crypto_context(a, b)
+    if source_a != output_shape:
+        a = broadcast_to(a, output_shape, order=a.order, cc=crypto_context)
+    if source_b != output_shape:
+        b = broadcast_to(b, output_shape, order=b.order, cc=crypto_context)
+
+    _require(
+        tuple(a.shape) == tuple(b.shape),
+        a.shape,
+        b.shape,
+        f"Logically aligned operands use different physical frames; got {a.shape} and {b.shape}.",
+        error_cls=ONPValueError,
+    )
+
+    return crypto_context, a, b
+
+
+# ------------------------------------------------------------------------------
+# Scalar logical-slot handling
+# ------------------------------------------------------------------------------
+
+
+def _logical_slot_indices(tensor):
+    """Return the physical slot indices representing logical tensor values.
+
+    Parameters
+    ----------
+    tensor
+        Packed tensor whose logical region is described by ``original_shape``.
+
+    Returns
+    -------
+    list[int]
+        Active slot indices in the tensor's packing order. Physical padding and
+        the batch tail are excluded; replicated vector lanes are included.
+
+    Raises
+    ------
+    ONPDimensionError
+        If the logical or physical rank is unsupported.
+    ONPValueError
+        If the logical shape exceeds the physical frame or the packing order is
+        unsupported.
+    """
+    logical_shape = tuple(tensor.original_shape)
+    if len(logical_shape) == 0:
+        return [0]
+
+    physical_shape = tuple(tensor.shape)
+    if len(logical_shape) == 1:
+        logical_length = logical_shape[0]
+        if len(physical_shape) == 1 or physical_shape[1] == 1:
+            return list(range(logical_length))
+
+        physical_rows, physical_cols = physical_shape
+        if logical_length > physical_rows:
+            raise ONPValueError(
+                f"logical shape {logical_shape} exceeds physical frame {tensor.shape}."
+            )
+        if tensor.order == ArrayEncodingType.ROW_MAJOR:
+            return [
+                row * physical_cols + col
+                for row in range(logical_length)
+                for col in range(physical_cols)
+            ]
+        if tensor.order == ArrayEncodingType.COL_MAJOR:
+            return [
+                col * physical_rows + row
+                for col in range(physical_cols)
+                for row in range(logical_length)
+            ]
+        raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
+
+    if len(logical_shape) != 2 or len(physical_shape) != 2:
+        raise ONPDimensionError(
+            f"Scalar arithmetic supports logical rank zero, one, or two; got {logical_shape}."
+        )
+
+    logical_rows, logical_cols = logical_shape
+    physical_rows, physical_cols = physical_shape
+    if logical_rows > physical_rows or logical_cols > physical_cols:
+        raise ONPValueError(f"logical shape {logical_shape} exceeds physical frame {tensor.shape}.")
+
+    if tensor.order == ArrayEncodingType.ROW_MAJOR:
+        return [
+            row * physical_cols + col for row in range(logical_rows) for col in range(logical_cols)
+        ]
+    if tensor.order == ArrayEncodingType.COL_MAJOR:
+        return [
+            col * physical_rows + row for col in range(logical_cols) for row in range(logical_rows)
+        ]
+    raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
+
+
+def _logical_plaintext(tensor, value, indices):
+    """Encode a scalar in logical slots and zero every inactive slot.
+
+    Parameters
+    ----------
+    tensor
+        Packed tensor providing the crypto context and batch size.
+    value
+        Python or NumPy numeric scalar to encode.
+    indices
+        Active slot indices returned by :func:`_logical_slot_indices`.
+
+    Returns
+    -------
+    Plaintext
+        CKKS packed plaintext with ``value`` in active slots.
+
+    Raises
+    ------
+    ONPValueError
+        If ``value`` is not a numeric scalar or an index exceeds the batch.
+    """
+    scalar = np.asarray(value)
+    if scalar.shape != () or not is_numeric_scalar(scalar):
+        raise ONPValueError(f"Expected a numeric scalar, got {value!r}.")
+    scalar = scalar.item()
+
+    slots = [0.0] * tensor.batch_size
+    for index in indices:
+        if index < 0 or index >= tensor.batch_size:
+            raise ONPValueError(
+                f"logical slot index {index} exceeds batch_size={tensor.batch_size}."
+            )
+        slots[index] = scalar
+
+    return tensor.data.GetCryptoContext().MakeCKKSPackedPlaintext(slots)
+
+
+def _mask_ciphertext_to_logical_slots(tensor, indices):
+    """Zero a ciphertext's physical padding and batch tail.
+
+    Parameters
+    ----------
+    tensor
+        Encrypted packed tensor to mask.
+    indices
+        Slot indices that belong to the tensor's logical region.
+
+    Returns
+    -------
+    Ciphertext
+        Original ciphertext when every batch slot is logical; otherwise a
+        masked ciphertext containing only logical slots.
+    """
+    if len(indices) == tensor.batch_size and all(
+        index == position for position, index in enumerate(indices)
+    ):
+        return tensor.data
+
+    crypto_context = tensor.data.GetCryptoContext()
+    mask = [0.0] * tensor.batch_size
+    for index in indices:
+        mask[index] = 1.0
+    return crypto_context.EvalMult(
+        tensor.data,
+        crypto_context.MakeCKKSPackedPlaintext(mask),
+    )
+
+
+# ------------------------------------------------------------------------------
+# Element-wise evaluation
+# ------------------------------------------------------------------------------
+
+
+def _eval_scalar_binary(tensor, scalar, operation, *, reverse=False):
+    """Evaluate scalar arithmetic while keeping inactive result slots zero.
+
+    Parameters
+    ----------
+    tensor
+        Encrypted packed tensor operand.
+    scalar
+        Python or NumPy numeric scalar operand.
+    operation
+        Supported operation name: ``add``, ``subtract``, or ``multiply``.
+    reverse
+        Evaluate ``scalar operation tensor`` when true; otherwise evaluate
+        ``tensor operation scalar``.
+
+    Returns
+    -------
+    CTArray
+        Metadata-preserving encrypted result.
+    """
+    crypto_context = tensor.data.GetCryptoContext()
+    indices = _logical_slot_indices(tensor)
+    scalar_plaintext = _logical_plaintext(tensor, scalar, indices)
+    eval_op = _resolve_eval_op(crypto_context, operation)
+
+    tensor_data = (
+        tensor.data
+        if operation == "multiply"
+        else _mask_ciphertext_to_logical_slots(tensor, indices)
+    )
+    lhs_data, rhs_data = (
+        (scalar_plaintext, tensor_data) if reverse else (tensor_data, scalar_plaintext)
+    )
+    return tensor.clone(eval_op(lhs_data, rhs_data))
+
+
+def _eval_binary(a, b, op_name):
+    """Align and evaluate one packed element-wise operation.
+
+    Parameters
+    ----------
+    a, b
+        Packed ciphertext/plaintext operands. At least one must be encrypted.
+    op_name
+        Supported operation name: ``add``, ``subtract``, or ``multiply``.
+
+    Returns
+    -------
+    CTArray
+        Encrypted result with the aligned logical/physical layout and metadata
+        from both operands.
+    """
+    crypto_context, a, b = _align_binary_operands(a, b)
+    result_data = _resolve_eval_op(crypto_context, op_name)(a.data, b.data)
+
+    encrypted, other = (a, b) if a.is_encrypted else (b, a)
+    result = encrypted.clone(result_data)
+    result.extra.update(other.extra)
+    return result

--- a/openfhe_numpy/operations/block_arithmetic.py
+++ b/openfhe_numpy/operations/block_arithmetic.py
@@ -52,7 +52,6 @@ from ..utils.errors import (
 from .block_arithmetic_utils import (
     _eval_block_binary,
     _eval_block_scalar,
-    _eval_scalar_block,
     _eval_block_dot,
     _eval_block_matmul,
 )
@@ -111,7 +110,7 @@ def subtract_block_ct_scalar(a, scalar):
 @register_tensor_function("subtract", [("scalar", "BlockCTArray")])
 def subtract_scalar_block_ct(scalar, a):
     """Subtract a block ciphertext tensor from a scalar."""
-    return _eval_scalar_block(scalar, a, "subtract")
+    return _eval_block_scalar(a, scalar, "subtract", reverse=True)
 
 
 # ------------------------------------------------------------------------------

--- a/openfhe_numpy/operations/block_arithmetic_utils.py
+++ b/openfhe_numpy/operations/block_arithmetic_utils.py
@@ -31,8 +31,7 @@
 
 from __future__ import annotations
 
-import operator
-from typing import Any, Callable
+from typing import Any
 
 from openfhe_numpy import ArrayEncodingType
 from openfhe_numpy.tensor.block_tensor import BlockFHETensor
@@ -44,41 +43,14 @@ from openfhe_numpy.utils.errors import (
 from openfhe_numpy.utils.typecheck import Number
 from openfhe_numpy.utils.matlib import _sum_terms
 from openfhe_numpy.operations.arithmetic_utils import (
+    _eval_binary,
+    _eval_scalar_binary,
     _result_cls,
     _require,
     _require_matvec_order,
     _get_matvec_key_name,
 )
 from openfhe_numpy.operations.block_broadcast import _align_block_operands
-
-
-# ------------------------------------------------------------------------------
-# Type aliases
-# ------------------------------------------------------------------------------
-
-BlockOp = Callable[[Any, Any], Any]
-
-
-# ------------------------------------------------------------------------------
-# Supported element-wise operators
-# ------------------------------------------------------------------------------
-
-_OPS: dict[str, BlockOp] = {
-    "add": operator.add,
-    "subtract": operator.sub,
-    "multiply": operator.mul,
-}
-
-
-def _resolve_op(op_name: str) -> BlockOp:
-    """Return the blockwise Python operator for ``op_name``."""
-    try:
-        return _OPS[op_name]
-    except KeyError:
-        supported = ", ".join(sorted(_OPS))
-        raise ONPNotImplementedError(
-            f"Unsupported block operation {op_name!r}. Supported operations: {supported}."
-        ) from None
 
 
 # ------------------------------------------------------------------------------
@@ -118,24 +90,26 @@ def _eval_block_binary(a: BlockFHETensor, b: BlockFHETensor, op_name: str) -> Bl
     """Evaluate a blockwise operation, broadcasting only compatible layouts"""
     a, b = _align_block_operands(a, b)
 
-    op = _resolve_op(op_name)
-    blocks = [op(left, right) for left, right in zip(a.data, b.data)]
+    blocks = [
+        _eval_binary(left, right, op_name)
+        for left, right in zip(a.data, b.data)
+    ]
 
     return _build_block_result(a, blocks, result_cls=BlockCTArray)
 
 
-def _eval_block_scalar(a: BlockFHETensor, scalar: Number, op_name: str) -> BlockFHETensor:
-    """Evaluate ``block_tensor op scalar`` blockwise."""
-    op = _resolve_op(op_name)
-    blocks = [op(block, scalar) for block in a.data]
-
-    return _build_block_result(a, blocks)
-
-
-def _eval_scalar_block(scalar: Number, a: BlockFHETensor, op_name: str) -> BlockFHETensor:
-    """Evaluate ``scalar op block_tensor`` blockwise."""
-    op = _resolve_op(op_name)
-    blocks = [op(scalar, block) for block in a.data]
+def _eval_block_scalar(
+    a: BlockFHETensor,
+    scalar: Number,
+    op_name: str,
+    *,
+    reverse: bool = False,
+) -> BlockFHETensor:
+    """Evaluate packed scalar arithmetic independently for every child block."""
+    blocks = [
+        _eval_scalar_binary(block, scalar, op_name, reverse=reverse)
+        for block in a.data
+    ]
 
     return _build_block_result(a, blocks)
 

--- a/openfhe_numpy/operations/block_broadcast.py
+++ b/openfhe_numpy/operations/block_broadcast.py
@@ -45,8 +45,11 @@ from typing import Any
 
 import numpy as np
 
-from openfhe_numpy.operations.arithmetic_utils import _require
-from openfhe_numpy.operations.broadcast import broadcast_to, generate_broadcast_key
+from openfhe_numpy.operations.arithmetic_utils import _binary_crypto_context, _require
+from openfhe_numpy.operations.broadcast import (
+    _broadcast_rotation_indices,
+    _broadcast_to_physical_slots,
+)
 from openfhe_numpy.tensor.block_ctarray import BlockCTArray
 from openfhe_numpy.tensor.block_tensor import BlockFHETensor
 from openfhe_numpy.utils.errors import (
@@ -178,55 +181,6 @@ def _block_original_shape(
 
 
 # ----------------------------------------------------------------------------
-# Crypto context
-# ----------------------------------------------------------------------------
-
-
-def _block_crypto_context(a: BlockFHETensor, b: BlockFHETensor):
-    """Return the crypto context shared by the encrypted operands.
-
-    Parameters
-    ----------
-    a, b : BlockFHETensor
-        Operands participating in the block operation.
-
-    Returns
-    -------
-    openfhe.CryptoContext
-        Crypto context associated with the encrypted operand or operands.
-
-    Raises
-    ------
-    ONPValueError
-        If both operands are plaintext or encrypted operands use different
-        crypto contexts or key tags.
-    """
-    encrypted = [tensor for tensor in (a, b) if tensor.is_encrypted]
-    _require(
-        bool(encrypted),
-        a.dtype,
-        b.dtype,
-        "Block arithmetic requires at least one encrypted operand.",
-        error_cls=ONPValueError,
-    )
-
-    first = encrypted[0].data[0].data
-    context = first.GetCryptoContext()
-    key_tag = first.GetKeyTag() if hasattr(first, "GetKeyTag") else None
-    for tensor in encrypted[1:]:
-        current = tensor.data[0].data
-        current_key_tag = current.GetKeyTag() if hasattr(current, "GetKeyTag") else None
-        _require(
-            current.GetCryptoContext() == context and current_key_tag == key_tag,
-            a.dtype,
-            b.dtype,
-            "Encrypted block operands must use the same crypto context and key tag.",
-            error_cls=ONPValueError,
-        )
-    return context
-
-
-# ----------------------------------------------------------------------------
 # Per-block expansion
 # ----------------------------------------------------------------------------
 
@@ -259,48 +213,82 @@ def _source_block(source: BlockFHETensor, kind: str, row: int, column: int):
     return source.get_block(row, 0)
 
 
-def _broadcast_block(source_block, out_original_shape, out_block_shape, order, context, kind):
-    """Expand one encoded source block to a result block.
-
-    Parameters
-    ----------
-    source_block : CTArray or PTArray
-        Encoded row or column block to expand.
-    out_original_shape : tuple[int, int]
-        Unpadded logical shape of the result block.
-    out_block_shape : tuple[int, int]
-        Padded shape of the result block.
-    order : ArrayEncodingType
-        Slot-packing order.
-    context : openfhe.CryptoContext
-        Crypto context used to encode plaintext results.
-    kind : {"row_vector", "row_matrix", "column"}
-        Broadcast direction of ``source_block``.
-
-    Returns
-    -------
-    CTArray or PTArray
-        Expanded encoded block with updated logical-shape metadata.
-    """
-    if kind == "column":
-        full_source_shape = (out_block_shape[0], 1)
-    else:
-        # Row vectors and row matrices share the same packed representation.
-        full_source_shape = (out_block_shape[1],)
-
-    # Edge blocks are already zero-padded. Expanding the full physical block
-    # preserves those zeros, so no separate edge mask is required.
-    full_source = source_block.clone()
-    full_source.original_shape = full_source_shape
-
-    expanded = broadcast_to(full_source, out_block_shape, order=order, cc=context)
-    expanded.original_shape = out_original_shape
-    return expanded
-
-
 # ----------------------------------------------------------------------------
 # Layout-driven broadcast
 # ----------------------------------------------------------------------------
+
+
+def _validate_source_for_layout(
+    source: BlockFHETensor,
+    original_shape: tuple[int, int],
+    block_shape: tuple[int, int],
+    grid_shape: tuple[int, int],
+    batch_size: int,
+    order: Any,
+) -> str:
+    """Validate a row or column source against a result block layout."""
+    _require(
+        len(original_shape) == 2,
+        original_shape,
+        source.original_shape,
+        "Block broadcasting produces a matrix result.",
+        error_cls=ONPNotSupportedError,
+    )
+    result_shape = _broadcast_shape(source.original_shape, original_shape)
+    _require(
+        result_shape == original_shape,
+        source.original_shape,
+        original_shape,
+        f"Broadcasting produces {result_shape}, not target shape {original_shape}.",
+    )
+    _require(
+        source.batch_size == batch_size,
+        source.batch_size,
+        batch_size,
+        f"Block broadcasting requires equal batch_size; got {source.batch_size} and {batch_size}.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        source.order == order,
+        source.order,
+        order,
+        f"Block broadcasting requires matching packing order; got {source.order!r} and {order!r}.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        not all(size == 1 for size in source.original_shape),
+        source.original_shape,
+        original_shape,
+        "Singleton block tensors are not broadcast operands; use a Python scalar.",
+        error_cls=ONPNotImplementedError,
+    )
+    _require(
+        _is_standard_block_layout(source),
+        tuple(source.data[0].shape),
+        source.block_shape,
+        "Block broadcasting requires standard non-compact packing; construct "
+        "vector sources with compact=False.",
+        error_cls=ONPNotSupportedError,
+    )
+
+    kind = _source_kind(source)
+    block_rows, block_cols = block_shape
+    grid_rows, grid_cols = grid_shape
+    expected_block, expected_grid = {
+        "row_vector": ((block_cols,), (grid_cols,)),
+        "row_matrix": ((1, block_cols), (1, grid_cols)),
+        "column": ((block_rows, 1), (grid_rows, 1)),
+    }[kind]
+    _require(
+        source.block_shape == expected_block and source.grid_shape == expected_grid,
+        source.block_shape,
+        block_shape,
+        "Incompatible block layout: result "
+        f"block_shape={block_shape} requires source "
+        f"block_shape={expected_block} and grid_shape={expected_grid}; "
+        f"got block_shape={source.block_shape} and grid_shape={source.grid_shape}.",
+    )
+    return kind
 
 
 def _broadcast_into_layout(
@@ -354,74 +342,40 @@ def _broadcast_into_layout(
     blocks of shape ``(br, bc)``, source blocks must have shape ``(bc,)``,
     ``(1, bc)``, or ``(br, 1)``.
     """
-    _require(
-        len(original_shape) == 2,
+    kind = _validate_source_for_layout(
+        source,
         original_shape,
-        source.original_shape,
-        "Block broadcasting produces a matrix result.",
-        error_cls=ONPNotSupportedError,
-    )
-    _require(
-        source.batch_size == batch_size,
-        source.batch_size,
-        batch_size,
-        f"Block broadcasting requires equal batch_size; got {source.batch_size} and {batch_size}.",
-        error_cls=ONPValueError,
-    )
-    _require(
-        source.order == order,
-        source.order,
-        order,
-        f"Block broadcasting requires matching packing order; got {source.order!r} and {order!r}.",
-        error_cls=ONPValueError,
-    )
-    _require(
-        not all(size == 1 for size in source.original_shape),
-        source.original_shape,
-        original_shape,
-        "Singleton block tensors are not broadcast operands; use a Python scalar.",
-        error_cls=ONPNotImplementedError,
-    )
-    _require(
-        _is_standard_block_layout(source),
-        tuple(source.data[0].shape),
-        source.block_shape,
-        "Block broadcasting requires standard non-compact packing; construct "
-        "vector sources with compact=False.",
-        error_cls=ONPNotSupportedError,
-    )
-
-    kind = _source_kind(source)
-    block_rows, block_cols = block_shape
-    grid_rows, grid_cols = grid_shape
-    # The source must match the result along every non-broadcast block axis.
-    expected_block, expected_grid = {
-        "row_vector": ((block_cols,), (grid_cols,)),
-        "row_matrix": ((1, block_cols), (1, grid_cols)),
-        "column": ((block_rows, 1), (grid_rows, 1)),
-    }[kind]
-    _require(
-        source.block_shape == expected_block and source.grid_shape == expected_grid,
-        source.block_shape,
         block_shape,
-        "Incompatible block layout: result "
-        f"block_shape={block_shape} requires source "
-        f"block_shape={expected_block} and grid_shape={expected_grid}; "
-        f"got block_shape={source.block_shape} and grid_shape={source.grid_shape}.",
+        grid_shape,
+        batch_size,
+        order,
     )
-
-    blocks = [
-        _broadcast_block(
-            _source_block(source, kind, i, j),
-            _block_original_shape(original_shape, block_shape, i, j),
-            block_shape,
-            order,
-            context,
+    cache = {}
+    blocks = []
+    for block_row, block_col in np.ndindex(*grid_shape):
+        source_block = _source_block(
+            source,
             kind,
+            block_row,
+            block_col,
         )
-        for i in range(grid_rows)
-        for j in range(grid_cols)
-    ]
+        logical_shape = _block_original_shape(
+            original_shape,
+            block_shape,
+            block_row,
+            block_col,
+        )
+        key = (id(source_block), logical_shape)
+        if key not in cache:
+            cache[key] = _broadcast_to_physical_slots(
+                source_block.clone(),
+                logical_shape=logical_shape,
+                physical_shape=block_shape,
+                order=order,
+                cc=context,
+            )
+        blocks.append(cache[key].clone())
+
     return result_cls(
         data=blocks,
         grid_shape=grid_shape,
@@ -479,7 +433,7 @@ def _block_broadcast_to(source: BlockFHETensor, target: BlockFHETensor) -> Block
         target.original_shape,
         f"Broadcasting produces {result_shape}, not target shape {target.original_shape}.",
     )
-    context = _block_crypto_context(source, target)
+    context = _binary_crypto_context(source.data[0], target.data[0])
     return _broadcast_into_layout(
         source,
         target.original_shape,
@@ -492,32 +446,12 @@ def _block_broadcast_to(source: BlockFHETensor, target: BlockFHETensor) -> Block
     )
 
 
-def _two_sided_broadcast(
-    a: BlockFHETensor, b: BlockFHETensor, result_shape: tuple[int, int]
-) -> tuple[BlockFHETensor, BlockFHETensor]:
-    """Broadcast a column and a row to a common matrix shape.
-
-    Parameters
-    ----------
-    a, b : BlockFHETensor
-        One column tensor and one row tensor.
-    result_shape : tuple[int, int]
-        Common logical matrix shape.
-
-    Returns
-    -------
-    tuple[BlockFHETensor, BlockFHETensor]
-        Expanded operands in their original order.
-
-    Raises
-    ------
-    ONPIncompatibleShapeError
-        If either source does not match the derived result layout.
-    ONPNotSupportedError
-        If the operands are not one column and one row.
-    ONPValueError
-        If their batch sizes, packing orders, or encryption metadata differ.
-    """
+def _two_sided_layout(
+    a: BlockFHETensor,
+    b: BlockFHETensor,
+    result_shape: tuple[int, int],
+) -> tuple[tuple[int, int], tuple[int, int], int, Any]:
+    """Validate a column-plus-row broadcast and return its common layout."""
     _require(
         len(result_shape) == 2,
         a.original_shape,
@@ -552,18 +486,53 @@ def _two_sided_broadcast(
         error_cls=ONPValueError,
     )
 
-    # The column defines the row partition; the row defines the column partition.
     block_shape = (column.block_shape[0], row.block_shape[-1])
     grid_shape = (column.grid_shape[0], row.grid_shape[-1])
-    context = _block_crypto_context(column, row)
+    return block_shape, grid_shape, column.batch_size, column.order
+
+
+def _two_sided_broadcast(
+    a: BlockFHETensor, b: BlockFHETensor, result_shape: tuple[int, int]
+) -> tuple[BlockFHETensor, BlockFHETensor]:
+    """Broadcast a column and a row to a common matrix shape.
+
+    Parameters
+    ----------
+    a, b : BlockFHETensor
+        One column tensor and one row tensor.
+    result_shape : tuple[int, int]
+        Common logical matrix shape.
+
+    Returns
+    -------
+    tuple[BlockFHETensor, BlockFHETensor]
+        Expanded operands in their original order.
+
+    Raises
+    ------
+    ONPIncompatibleShapeError
+        If either source does not match the derived result layout.
+    ONPNotSupportedError
+        If the operands are not one column and one row.
+    ONPValueError
+        If their batch sizes, packing orders, or encryption metadata differ.
+    """
+    a_is_column = _source_kind(a) == "column"
+    column, row = (a, b) if a_is_column else (b, a)
+    block_shape, grid_shape, batch_size, order = _two_sided_layout(
+        column,
+        row,
+        result_shape,
+    )
+    context = _binary_crypto_context(column.data[0], row.data[0])
 
     column_full = _broadcast_into_layout(
         column,
         result_shape,
         block_shape,
         grid_shape,
-        column.batch_size,
-        column.order,
+        batch_size,
+        order,
         context,
         type(column),
     )
@@ -572,8 +541,8 @@ def _two_sided_broadcast(
         result_shape,
         block_shape,
         grid_shape,
-        column.batch_size,
-        column.order,
+        batch_size,
+        order,
         context,
         type(row),
     )
@@ -737,6 +706,8 @@ def generate_block_broadcast_key(secret_key: Any, *operands: BlockFHETensor) -> 
         )
         _verify_secret_key(secret_key, operand)
 
+    requests = set()
+
     if len(operands) == 1:
         matrix = operands[0]
         _require(
@@ -746,20 +717,120 @@ def generate_block_broadcast_key(secret_key: Any, *operands: BlockFHETensor) -> 
             "A single-operand call must be a block matrix.",
             error_cls=ONPTypeError,
         )
-        block_rows, block_cols = matrix.block_shape
-        target_block = matrix.block_shape
-        source_shapes = {(block_cols,), (block_rows, 1)}
-    else:
-        target_block = _broadcast_shape(*(operand.block_shape for operand in operands))
-        if len(target_block) != 2:
-            return  # operands share a block shape; no broadcast, no keys
-        block_rows, block_cols = target_block
-        source_shapes = set()
-        for operand in operands:
-            if tuple(operand.block_shape) == target_block:
-                continue  # full-size operand needs no expansion keys
-            kind = _source_kind(operand)
-            source_shapes.add((block_rows, 1) if kind == "column" else (block_cols,))
+        result_shape = matrix.original_shape
+        physical_shape = matrix.block_shape
+        grid_shape = matrix.grid_shape
+        order = matrix.order
 
-    for source_shape in source_shapes:
-        generate_broadcast_key(secret_key, source_shape, target_block)
+        for block_row, block_col in np.ndindex(*grid_shape):
+            logical_shape = _block_original_shape(
+                result_shape,
+                physical_shape,
+                block_row,
+                block_col,
+            )
+            logical_rows, logical_cols = logical_shape
+
+            # Row vectors and row matrices use the same packed-slot kernel.
+            requests.add(((logical_cols,), logical_shape))
+            requests.add(((logical_rows, 1), logical_shape))
+
+    else:
+        result_shape = _broadcast_shape(*(operand.original_shape for operand in operands))
+        if len(result_shape) != 2:
+            return
+
+        full_operands = [operand for operand in operands if operand.original_shape == result_shape]
+        if full_operands:
+            target = full_operands[0]
+            for other in full_operands[1:]:
+                _require(
+                    target.same_layout(other),
+                    target.block_shape,
+                    other.block_shape,
+                    "Full matrix operands use different layouts; broadcasting cannot re-tile them.",
+                )
+
+            physical_shape = target.block_shape
+            grid_shape = target.grid_shape
+            batch_size = target.batch_size
+            order = target.order
+
+        else:
+            classified = [(operand, _source_kind(operand)) for operand in operands]
+            column = next(
+                (operand for operand, kind in classified if kind == "column"),
+                None,
+            )
+            row = next(
+                (operand for operand, kind in classified if kind != "column"),
+                None,
+            )
+            _require(
+                column is not None and row is not None,
+                tuple(operand.original_shape for operand in operands),
+                result_shape,
+                "Two-sided block broadcasting needs at least one column and one row "
+                "when no full matrix operand defines the result layout.",
+                error_cls=ONPNotSupportedError,
+            )
+            physical_shape, grid_shape, batch_size, order = _two_sided_layout(
+                column,
+                row,
+                result_shape,
+            )
+
+        for operand in operands:
+            if operand.original_shape == result_shape:
+                # Full operands define this layout and require no expansion.
+                continue
+
+            kind = _validate_source_for_layout(
+                operand,
+                result_shape,
+                physical_shape,
+                grid_shape,
+                batch_size,
+                order,
+            )
+            for block_row, block_col in np.ndindex(*grid_shape):
+                logical_shape = _block_original_shape(
+                    result_shape,
+                    physical_shape,
+                    block_row,
+                    block_col,
+                )
+                source_block = _source_block(
+                    operand,
+                    kind,
+                    block_row,
+                    block_col,
+                )
+
+                # A logical match alone does not prove packed-slot identity.
+                if (
+                    tuple(source_block.original_shape) == logical_shape
+                    and tuple(source_block.shape) == physical_shape
+                    and source_block.order == order
+                ):
+                    continue
+
+                requests.add((tuple(source_block.original_shape), logical_shape))
+
+    indices = set()
+    for source_shape, logical_shape in requests:
+        indices.update(
+            _broadcast_rotation_indices(
+                source_shape=source_shape,
+                logical_shape=logical_shape,
+                physical_shape=physical_shape,
+                order=order,
+            )
+        )
+
+    indices.discard(0)
+    if indices:
+        secret_key.GetCryptoContext().EvalRotateKeyGen(
+            secret_key,
+            sorted(indices),
+        )

--- a/openfhe_numpy/operations/broadcast.py
+++ b/openfhe_numpy/operations/broadcast.py
@@ -1,4 +1,4 @@
-# ==============================================================================
+# ================================================================================
 #  BSD 2-Clause License
 #
 #  Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
@@ -28,388 +28,765 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ================================================================================
-"""
-matrix_arithmetic.py
+"""Broadcast scalar-like, row, and column packed tensors."""
 
-This module implements the core arithmetic operations for encrypted tensors
-using the OpenFHE library. Operations include addition, subtraction, multiplication,
-matrix multiplication, and other mathematical operations.
-"""
+from math import prod
+from operator import index as operator_index
 
-# Third-party imports
 import numpy as np
+
 from ..openfhe_numpy import ArrayEncodingType
+from ..tensor.constructors import _pack_block, array
+from ..tensor.ctarray import CTArray
+from ..utils._helper_slots_ops import (
+    _create_masking,
+    _replicate_pattern,
+    _replication_steps,
+)
+from ..utils.errors import (
+    ONPDimensionError,
+    ONPIncompatibleShapeError,
+    ONPNotSupportedError,
+    ONPValueError,
+    _require,
+)
 from ..utils.matlib import next_power_of_two
-from ..utils._helper_slots_ops import _create_masking, _duplicate_block
-from ..tensor.constructors import array
 
 
 # ------------------------------------------------------------------------------
-# Utilities functions for broadcasting
+# Shape and layout validation
 # ------------------------------------------------------------------------------
 
 
-def broadcast_shapes(x_shape, y_shape):
-    return np.broadcast_shapes(x_shape, y_shape)
+def _normalize_shape(shape, name):
+    """Normalize a logical or physical shape.
 
+    Parameters
+    ----------
+    shape
+        Iterable of integer-compatible dimensions. The empty scalar shape is
+        allowed.
+    name
+        User-facing name included in validation errors.
 
-# Broadcasting rules: expand operands to a common shape (x, y) -> (a, b)
-#
-# 1. Scalar: () -> (1, 1)
-#    1 + 2                     -> 3
-#    1 + [1, 2, 3]             -> [2, 3, 4]
-#    1 + [[1, 2], [3, 4]]      -> [[6, 7], [8, 9]]
-#
-# 2. Vector: (n,) -> (1, n)
-#    - (n,) + (n,)             -> (n,)
-#      Example: [1, 2, 3] + [10, 20, 30]
-#               -> [11, 22, 33]
-#
-#    - (m, n) + (n,)           -> (m, n)
-#      Example: [[1, 2, 3],
-#                [4, 5, 6]] + [10, 20, 30]
-#               -> [[11, 22, 33],
-#                   [14, 25, 36]]
-#
-# 3. Matrix: (m, n) -> (m, n)
+    Returns
+    -------
+    tuple[int, ...]
+        Shape containing positive Python integers, or ``()`` for a scalar.
 
-
-# ------------------------------------------------------------------------------
-# Rotation index helpers
-# ------------------------------------------------------------------------------
-
-
-def _duplicate_block_indices(duplicate_count, block_size) -> set:
+    Raises
+    ------
+    ONPValueError
+        If ``shape`` is not iterable, contains a non-integral dimension, or
+        contains a nonpositive dimension.
     """
-    Mirrors the rotation pattern inside _duplicate_block:
+    try:
+        normalized = tuple(operator_index(size) for size in shape)
+    except TypeError as exc:
+        raise ONPValueError(f"{name} must be a shape, got {shape!r}") from exc
+
+    if any(size <= 0 for size in normalized):
+        raise ONPValueError(f"{name} must contain positive dimensions, got {normalized}")
+    return normalized
+
+
+def _require_broadcast_target(source_shape, logical_shape):
+    """Require NumPy broadcasting to produce the requested logical shape.
+
+    Parameters
+    ----------
+    source_shape
+        Normalized logical shape of the source tensor.
+    logical_shape
+        Normalized logical shape requested by the caller.
+
+    Returns
+    -------
+    tuple[int, ...]
+        NumPy broadcast result, which is guaranteed to equal ``logical_shape``.
+
+    Raises
+    ------
+    ONPIncompatibleShapeError
+        If the shapes cannot broadcast or broadcasting produces a different
+        result shape.
     """
+    try:
+        result_shape = tuple(np.broadcast_shapes(source_shape, logical_shape))
+    except ValueError as exc:
+        raise ONPIncompatibleShapeError(
+            source_shape,
+            logical_shape,
+            f"cannot broadcast {source_shape} to {logical_shape}",
+        ) from exc
+    if result_shape != logical_shape:
+        raise ONPIncompatibleShapeError(
+            source_shape,
+            logical_shape,
+            f"broadcasting produces {result_shape}, not {logical_shape}",
+        )
+    return result_shape
+
+
+def _slot_source_kind(source_shape):
+    """Classify a packed source for matrix broadcasting.
+
+    Parameters
+    ----------
+    source_shape
+        Logical source shape already validated against the matrix target.
+
+    Returns
+    -------
+    str
+        ``scalar``, ``row``, or ``column``.
+
+    Raises
+    ------
+    ONPNotSupportedError
+        If the source is a general matrix or otherwise has no broadcast kernel.
+    """
+    if prod(source_shape) == 1:
+        return "scalar"
+    if len(source_shape) == 1:
+        return "row"
+    if len(source_shape) == 2 and source_shape[0] == 1:
+        return "row"
+    if len(source_shape) == 2 and source_shape[1] == 1:
+        return "column"
+    raise ONPNotSupportedError(f"unsupported broadcast source shape {source_shape}")
+
+
+def _validate_matrix_broadcast_geometry(
+    source_shape,
+    logical_shape,
+    physical_shape,
+    order,
+    *,
+    allow_order_union,
+):
+    """Validate one logical matrix broadcast and its physical slot frame.
+
+    Parameters
+    ----------
+    source_shape
+        Logical source shape.
+    logical_shape
+        Requested two-dimensional logical result shape.
+    physical_shape
+        Two-dimensional padded slot frame for the result.
+    order
+        Required packing order, or ``None`` when key planning may union both
+        supported orders.
+    allow_order_union
+        Whether ``order=None`` is valid.
+
+    Returns
+    -------
+    tuple
+        Normalized ``(source_shape, logical_shape, physical_shape)``.
+
+    Raises
+    ------
+    ONPDimensionError
+        If source or frame ranks are unsupported.
+    ONPIncompatibleShapeError
+        If the logical result exceeds the physical frame or the source cannot
+        broadcast to the requested logical shape.
+    ONPValueError
+        If the packing order is missing or invalid.
+    """
+    source_shape = _normalize_shape(source_shape, "source shape")
+    logical_shape = _normalize_shape(logical_shape, "logical shape")
+    physical_shape = _normalize_shape(physical_shape, "physical shape")
+
+    _require(
+        len(source_shape) <= 2,
+        source_shape,
+        logical_shape,
+        f"unsupported source rank {len(source_shape)}",
+        error_cls=ONPDimensionError,
+    )
+    _require(
+        len(logical_shape) == 2 and len(physical_shape) == 2,
+        logical_shape,
+        physical_shape,
+        "matrix broadcasting requires two-dimensional frames",
+        error_cls=ONPDimensionError,
+    )
+
+    valid_orders = (
+        ArrayEncodingType.ROW_MAJOR,
+        ArrayEncodingType.COL_MAJOR,
+    )
+    if order is None:
+        _require(
+            allow_order_union,
+            order,
+            None,
+            "matrix packing order is required",
+            error_cls=ONPValueError,
+        )
+    else:
+        _require(
+            order in valid_orders,
+            order,
+            None,
+            f"invalid matrix packing order {order!r}",
+            error_cls=ONPValueError,
+        )
+
+    _require(
+        all(logical <= physical for logical, physical in zip(logical_shape, physical_shape)),
+        logical_shape,
+        physical_shape,
+        f"logical_shape={logical_shape} exceeds physical_shape={physical_shape}",
+    )
+
+    _require_broadcast_target(source_shape, logical_shape)
+
+    return source_shape, logical_shape, physical_shape
+
+
+# ------------------------------------------------------------------------------
+# Rotation planning and key generation
+# ------------------------------------------------------------------------------
+
+
+def _broadcast_rotation_indices(
+    source_shape,
+    logical_shape,
+    physical_shape,
+    order=None,
+):
+    """Plan rotations for one logical/physical broadcast layout.
+
+    Parameters
+    ----------
+    source_shape
+        Logical source shape.
+    logical_shape
+        Requested logical result shape.
+    physical_shape
+        Padded physical slot frame.
+    order
+        Packing order to plan, or ``None`` to union both supported matrix
+        orders.
+
+    Returns
+    -------
+    set[int]
+        Nonzero signed rotation indices used by the runtime kernels.
+
+    Raises
+    ------
+    ONPDimensionError
+        If source or frame ranks are unsupported.
+    ONPIncompatibleShapeError
+        If the source cannot broadcast to the requested logical frame.
+    ONPNotSupportedError
+        If no vector or matrix broadcast kernel supports the source shape.
+    ONPValueError
+        If the physical frame or packing order is invalid.
+    """
+    source_shape = _normalize_shape(source_shape, "source shape")
+    logical_shape = _normalize_shape(logical_shape, "logical shape")
+    physical_shape = _normalize_shape(physical_shape, "physical shape")
     indices = set()
-    rotation = block_size
-    while rotation < block_size * duplicate_count:
-        indices.add(-rotation)
-        rotation *= 2
+
+    def add_replication(copies, stride):
+        indices.update(
+            rotation for rotation, _ in _replication_steps(copies, stride)
+        )
+
+    if len(logical_shape) == 1:
+        _require(
+            len(physical_shape) == 2
+            and physical_shape[1] == 1
+            and logical_shape[0] <= physical_shape[0],
+            logical_shape,
+            physical_shape,
+            f"invalid vector frame: logical={logical_shape}, physical={physical_shape}",
+            error_cls=ONPValueError,
+        )
+
+        _require_broadcast_target(source_shape, logical_shape)
+        _require(
+            _slot_source_kind(source_shape) == "scalar",
+            source_shape,
+            logical_shape,
+            "only scalar-like data can expand to a vector",
+            error_cls=ONPNotSupportedError,
+        )
+
+        if order is not None:
+            _require(
+                order in (ArrayEncodingType.ROW_MAJOR, ArrayEncodingType.COL_MAJOR),
+                order,
+                None,
+                f"invalid vector packing order {order!r}",
+                error_cls=ONPValueError,
+            )
+
+        add_replication(logical_shape[0], 1)
+        return indices
+
+    source_shape, logical_shape, physical_shape = (
+        _validate_matrix_broadcast_geometry(
+            source_shape=source_shape,
+            logical_shape=logical_shape,
+            physical_shape=physical_shape,
+            order=order,
+            allow_order_union=True,
+        )
+    )
+    source_kind = _slot_source_kind(source_shape)
+
+    logical_rows, logical_cols = logical_shape
+    physical_rows, physical_cols = physical_shape
+    orders = (
+        (ArrayEncodingType.ROW_MAJOR, ArrayEncodingType.COL_MAJOR)
+        if order is None
+        else (order,)
+    )
+
+    for current_order in orders:
+        if source_kind == "scalar":
+            if current_order == ArrayEncodingType.ROW_MAJOR:
+                add_replication(logical_cols, 1)
+                add_replication(logical_rows, physical_cols)
+            else:
+                add_replication(logical_rows, 1)
+                add_replication(logical_cols, physical_rows)
+
+        elif source_kind == "row":
+            source_cols = source_shape[-1]
+            if current_order == ArrayEncodingType.ROW_MAJOR:
+                add_replication(logical_rows, physical_cols)
+            else:
+                indices.update(
+                    -i * (physical_rows - 1)
+                    for i in range(1, source_cols)
+                )
+                add_replication(logical_rows, 1)
+
+        elif source_kind == "column":
+            source_rows = source_shape[0]
+            if current_order == ArrayEncodingType.COL_MAJOR:
+                add_replication(logical_cols, physical_rows)
+            else:
+                indices.update(
+                    -i * (physical_cols - 1)
+                    for i in range(1, source_rows)
+                )
+                add_replication(logical_cols, 1)
+
+    indices.discard(0)
     return indices
 
 
-# ------------------------------------------------------------------------------
-# Key generation
-# ------------------------------------------------------------------------------
-
-
 def generate_broadcast_key(secret_key, original_shape, target_shape):
-    """
-    Pre-generate all rotation keys needed by broadcast_to for a given
-    (original_shape, target_shape) pair - for both ROW_MAJOR and COL_MAJOR.
+    """Generate rotations needed to broadcast one packed tensor."""
+    logical_shape = _normalize_shape(target_shape, "target_shape")
 
-    Broadcasting cases covered:
-      Scalar  ()      -> Vector (n,)
-      Scalar  ()      -> Matrix (m, n)
-      Vector  (n,)    -> Matrix (m, n)
-      ColVec  (m, 1)  -> Matrix (m, n)
-    """
-    if target_shape == ():
+    # Direct broadcasting preserves logical identity without repacking. The source
+    # shape is normalized and validated inside _broadcast_rotation_indices, so it is
+    # passed through raw rather than normalized a second time here.
+    if tuple(original_shape) == logical_shape:
         return
 
-    cc = secret_key.GetCryptoContext()
-    indices = set()
+    if len(logical_shape) == 1:
+        physical_shape = (next_power_of_two(logical_shape[0]), 1)
+    elif len(logical_shape) == 2:
+        physical_shape = tuple(next_power_of_two(size) for size in logical_shape)
+    else:
+        raise ONPNotSupportedError(f"target shape {logical_shape} is not supported")
 
-    # --- Scalar -> Vector ---
-    if len(target_shape) == 1:
-        nrow = target_shape[0]
-        if original_shape == ():
-            rotation = 1
-            while rotation < nrow:
-                indices.add(-rotation)
-                rotation *= 2
+    context = secret_key.GetCryptoContext()
+    _require(
+        physical_shape[0] * physical_shape[1] <= context.GetBatchSize(),
+        physical_shape,
+        None,
+        f"physical_shape={physical_shape} exceeds the crypto-context batch size",
+        error_cls=ONPValueError,
+    )
 
-    # --- Any -> Matrix ---
-    elif len(target_shape) == 2:
-        nrow, ncol = target_shape
-        nrow_pow_2 = next_power_of_two(nrow)
-        ncol_pow_2 = next_power_of_two(ncol)
-
-        if original_shape == ():
-            indices.update(_duplicate_block_indices(nrow, ncol_pow_2))
-            indices.update(_duplicate_block_indices(ncol, 1))
-            indices.update(_duplicate_block_indices(ncol, nrow_pow_2))
-            indices.update(_duplicate_block_indices(nrow, 1))
-
-        elif len(original_shape) == 1:
-            indices.update(_duplicate_block_indices(nrow, ncol_pow_2))
-            for i in range(1, original_shape[0]):
-                indices.add(-i * (nrow_pow_2 - 1))
-            indices.update(_duplicate_block_indices(nrow, 1))
-
-        elif len(original_shape) == 2:
-            indices.update(_duplicate_block_indices(ncol_pow_2, nrow_pow_2))
-            for i in range(1, original_shape[0]):
-                indices.add(-i * (ncol_pow_2 - 1))
-            indices.update(_duplicate_block_indices(ncol, 1))
-
-    cc.EvalRotateKeyGen(secret_key, sorted(indices))
+    indices = _broadcast_rotation_indices(
+        source_shape=original_shape,
+        logical_shape=logical_shape,
+        physical_shape=physical_shape,
+        order=None,
+    )
+    if indices:
+        context.EvalRotateKeyGen(secret_key, sorted(indices))
 
 
 # ------------------------------------------------------------------------------
-# Broadcasting
+# Public runtime dispatch
 # ------------------------------------------------------------------------------
 
 
 def broadcast_to(x, target_shape, order=None, cc=None):
+    """Broadcast ``x`` to a logical NumPy target shape."""
+    source_shape = _normalize_shape(x.original_shape, "source shape")
+    logical_shape = _normalize_shape(target_shape, "target_shape")
+
+    _require_broadcast_target(source_shape, logical_shape)
+
+    # Preserve the existing logical no-op, including order=None and tiled tails.
+    if source_shape == logical_shape:
+        return x
+
+    if len(logical_shape) == 1:
+        return _broadcast_to_vector(x, logical_shape, order=order, cc=cc)
+
+    if len(logical_shape) == 2:
+        physical_shape = tuple(next_power_of_two(size) for size in logical_shape)
+        return _broadcast_to_physical_slots(
+            x,
+            logical_shape=logical_shape,
+            physical_shape=physical_shape,
+            order=order,
+            cc=cc,
+        )
+
+    raise ONPNotSupportedError(f"target shape {logical_shape} is not supported")
+
+
+# ------------------------------------------------------------------------------
+# Vector broadcasting
+# ------------------------------------------------------------------------------
+
+
+def _broadcast_to_vector(x, logical_shape, order=None, cc=None):
+    """Broadcast scalar-like packed data into a logical vector.
+
+    Parameters
+    ----------
+    x
+        Scalar-like ``CTArray`` or ``PTArray`` source.
+    logical_shape
+        Normalized one-dimensional target shape.
+    order
+        Requested packing order, or ``None`` to preserve the source order.
+    cc
+        Crypto context required when constructing a plaintext result.
+
+    Returns
+    -------
+    CTArray or PTArray
+        Vector with physical shape ``(next_power_of_two(length), 1)`` and zero
+        padding outside its logical region.
+
+    Raises
+    ------
+    ONPNotSupportedError
+        If the source is not scalar-like or has an unsupported tensor type.
+    ONPValueError
+        If the physical vector exceeds the batch, the order is invalid, or a
+        plaintext source is missing its crypto context.
+    """
+    logical_length = logical_shape[0]
+    padded_length = next_power_of_two(logical_length)
+    physical_shape = (padded_length, 1)
+
+    _require(
+        padded_length <= x.batch_size,
+        padded_length,
+        x.batch_size,
+        f"physical vector length {padded_length} exceeds batch_size={x.batch_size}",
+        error_cls=ONPValueError,
+    )
+    _require(
+        _slot_source_kind(tuple(x.original_shape)) == "scalar",
+        x.original_shape,
+        None,
+        f"only scalar-like data can expand to a vector; got {x.original_shape}",
+        error_cls=ONPNotSupportedError,
+    )
+
+    resolved_order = x.order if order is None else order
+    _require(
+        resolved_order in (ArrayEncodingType.ROW_MAJOR, ArrayEncodingType.COL_MAJOR),
+        resolved_order,
+        None,
+        f"invalid vector packing order {resolved_order!r}",
+        error_cls=ONPValueError,
+    )
+
     if x.dtype == "CTArray":
-        return _ct_broadcast_to(x, target_shape, order)
-    elif x.dtype == "PTArray":
-        return _pt_broadcast_to(x, target_shape, order, cc)
-    else:
-        raise ValueError(f"Broadcast doesn't support {type(x)}")
+        seed = _isolate_ciphertext(x.data, [0], x.batch_size)
+        result_data = _replicate_pattern(
+            seed,
+            copies=logical_length,
+            stride=1,
+        )
+        return CTArray(
+            data=result_data,
+            original_shape=logical_shape,
+            batch_size=x.batch_size,
+            new_shape=physical_shape,
+            order=resolved_order,
+        )
+
+    if x.dtype == "PTArray":
+        _require(
+            cc is not None,
+            None,
+            None,
+            "broadcasting plaintext data requires a crypto context",
+            error_cls=ONPValueError,
+        )
+        logical_values = np.broadcast_to(
+            x.decode(unpack_type="original"),
+            logical_shape,
+        )
+        return array(
+            cc=cc,
+            data=np.asarray(logical_values),
+            batch_size=x.batch_size,
+            order=resolved_order,
+            fhe_type="P",
+            mode="zero",
+        )
+
+    raise ONPNotSupportedError(f"broadcast does not support {type(x)}")
 
 
-def _pt_broadcast_to(pta_x, target_shape, order=None, cc=None):
-    target_shape = tuple(target_shape)
+# ------------------------------------------------------------------------------
+# Matrix broadcasting
+# ------------------------------------------------------------------------------
 
-    if target_shape == pta_x.original_shape:
-        return pta_x
 
-    def _make_array(data):
-        if cc is not None:
-            return array(
-                cc=cc,
-                data=data,
-                batch_size=pta_x.batch_size,
-                order=order,
-                fhe_type="P",
-                mode="zero",
+def _broadcast_to_physical_slots(
+    x,
+    logical_shape,
+    physical_shape,
+    order=None,
+    cc=None,
+):
+    """Broadcast packed data into a specified matrix slot frame.
+
+    Parameters
+    ----------
+    x
+        Packed ``CTArray`` or ``PTArray`` source.
+    logical_shape
+        Requested logical matrix shape.
+    physical_shape
+        Padded physical matrix frame.
+    order
+        Required row-major or column-major packing order.
+    cc
+        Crypto context required when constructing a plaintext result.
+
+    Returns
+    -------
+    CTArray or PTArray
+        Broadcast result carrying the requested logical and physical metadata.
+
+    Raises
+    ------
+    ONPDimensionError
+        If source or frame ranks are unsupported.
+    ONPIncompatibleShapeError
+        If source, logical, and physical shapes are incompatible.
+    ONPNotSupportedError
+        If the source shape or tensor type has no supported kernel.
+    ONPValueError
+        If the order, batch capacity, or plaintext context is invalid.
+    """
+    source_shape, logical_shape, physical_shape = (
+        _validate_matrix_broadcast_geometry(
+            source_shape=x.original_shape,
+            logical_shape=logical_shape,
+            physical_shape=physical_shape,
+            order=order,
+            allow_order_union=False,
+        )
+    )
+
+    _require(
+        physical_shape[0] * physical_shape[1] <= x.batch_size,
+        physical_shape,
+        x.batch_size,
+        f"physical_shape={physical_shape} exceeds batch_size={x.batch_size}",
+        error_cls=ONPValueError,
+    )
+
+    # Packed identity requires logical, physical, and order equality.
+    if (
+        source_shape == logical_shape
+        and tuple(x.shape) == physical_shape
+        and x.order == order
+    ):
+        return x
+
+    source_kind = _slot_source_kind(source_shape)
+    if x.dtype == "CTArray":
+        return _ct_broadcast_to(
+            x,
+            logical_shape,
+            physical_shape,
+            order,
+            source_kind,
+        )
+    if x.dtype == "PTArray":
+        return _pt_broadcast_to(
+            x,
+            logical_shape,
+            physical_shape,
+            order,
+            cc,
+        )
+    raise ONPNotSupportedError(f"broadcast does not support {type(x)}")
+
+
+# ------------------------------------------------------------------------------
+# Ciphertext broadcast helpers
+# ------------------------------------------------------------------------------
+
+
+def _isolate_ciphertext(data, indices, batch_size):
+    """Mask a ciphertext to a selected set of source slots.
+
+    Parameters
+    ----------
+    data
+        Ciphertext containing the packed source values.
+    indices
+        Slot indices to retain.
+    batch_size
+        Total number of packed slots.
+
+    Returns
+    -------
+    Ciphertext
+        Ciphertext with every slot outside ``indices`` set to zero.
+    """
+    context = data.GetCryptoContext()
+    mask = _create_masking(indices, batch_size)
+    return context.EvalMult(data, context.MakeCKKSPackedPlaintext(mask))
+
+
+def _ct_broadcast_to(x, logical_shape, physical_shape, order, source_kind):
+    context = x.data.GetCryptoContext()
+    logical_rows, logical_cols = logical_shape
+    physical_rows, physical_cols = physical_shape
+
+    if source_kind == "scalar":
+        seed = _isolate_ciphertext(x.data, [0], x.batch_size)
+        if order == ArrayEncodingType.ROW_MAJOR:
+            first_row = _replicate_pattern(seed, logical_cols, 1)
+            result_data = _replicate_pattern(
+                first_row,
+                logical_rows,
+                physical_cols,
             )
-        raise ValueError("Broadcasting operation requires a crypto context")
+        else:
+            first_column = _replicate_pattern(seed, logical_rows, 1)
+            result_data = _replicate_pattern(
+                first_column,
+                logical_cols,
+                physical_rows,
+            )
 
-    packed = pta_x.data.GetRealPackedValue()
+    elif source_kind == "row":
+        source_cols = tuple(x.original_shape)[-1]
+        if order == ArrayEncodingType.ROW_MAJOR:
+            seed_row = _isolate_ciphertext(
+                x.data,
+                range(source_cols),
+                x.batch_size,
+            )
+            result_data = _replicate_pattern(
+                seed_row,
+                logical_rows,
+                physical_cols,
+            )
+        else:
+            first_row = _isolate_ciphertext(x.data, [0], x.batch_size)
+            for i in range(1, source_cols):
+                element = _isolate_ciphertext(x.data, [i], x.batch_size)
+                rotation = -i * (physical_rows - 1)
+                if rotation:
+                    element = context.EvalRotate(element, rotation)
+                first_row = context.EvalAdd(first_row, element)
+            result_data = _replicate_pattern(first_row, logical_rows, 1)
 
-    # --- Scalar () -> anything ---
-    if pta_x.original_shape == ():
-        x = np.broadcast_to(np.array(packed[0]), target_shape)
-        return _make_array(x)
+    elif source_kind == "column":
+        source_rows = tuple(x.original_shape)[0]
+        if order == ArrayEncodingType.COL_MAJOR:
+            seed_column = _isolate_ciphertext(
+                x.data,
+                range(source_rows),
+                x.batch_size,
+            )
+            result_data = _replicate_pattern(
+                seed_column,
+                logical_cols,
+                physical_rows,
+            )
+        else:
+            first_column = _isolate_ciphertext(x.data, [0], x.batch_size)
+            for i in range(1, source_rows):
+                element = _isolate_ciphertext(x.data, [i], x.batch_size)
+                rotation = -i * (physical_cols - 1)
+                if rotation:
+                    element = context.EvalRotate(element, rotation)
+                first_column = context.EvalAdd(first_column, element)
+            result_data = _replicate_pattern(first_column, logical_cols, 1)
 
-    # --- 1D (n,) -> (m, n) ---
-    if len(pta_x.original_shape) == 1:
-        n = pta_x.original_shape[0]
-        x = np.array(packed[:n])  # shape (n,)
-        x_broadcasted = np.broadcast_to(x, target_shape)
-        return _make_array(x_broadcasted)
+    else:  # Defensive: source kinds are produced only by _slot_source_kind().
+        raise ONPValueError(f"unsupported broadcast source kind {source_kind!r}")
 
-    # --- 2D (m,1) -> (m,n)  or  (1,n) -> (m,n) ---
-    if len(pta_x.original_shape) == 2:
-        m, n = pta_x.original_shape
-        x = np.array(packed[: m * n]).reshape(pta_x.original_shape)  # restore 2D shape
-        x_broadcasted = np.broadcast_to(x, target_shape)
-        return _make_array(x_broadcasted)
-
-    raise ValueError(
-        f"Incompatible shapes: {pta_x.original_shape} "
-        f"cannot be broadcast to target matrix shape {target_shape}."
+    return CTArray(
+        data=result_data,
+        original_shape=logical_shape,
+        batch_size=x.batch_size,
+        new_shape=physical_shape,
+        order=order,
     )
 
 
-def _ct_broadcast_to(x, target_shape, order=None):
-    from openfhe_numpy.tensor.ctarray import CTArray
+# ------------------------------------------------------------------------------
+# Plaintext matrix broadcasting
+# ------------------------------------------------------------------------------
 
-    target_shape = tuple(target_shape)
-    if target_shape == x.original_shape:
-        return x
 
-    cc = x.data.GetCryptoContext()
+def _pt_broadcast_to(
+    pta_x,
+    logical_shape,
+    physical_shape,
+    order=None,
+    cc=None,
+):
+    _require(
+        cc is not None,
+        None,
+        None,
+        "broadcasting plaintext data requires a crypto context",
+        error_cls=ONPValueError,
+    )
 
-    # --- Scalar -> anything ---
-    if x.original_shape == ():
-        if target_shape == ():
-            return x
+    source_values = pta_x.decode(unpack_type="original")
+    logical_values = np.broadcast_to(source_values, logical_shape)
 
-        # Scalar -> Vector
-        elif len(target_shape) == 1:
-            mask = _create_masking([0], x.batch_size)
-            pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-            ct_res = cc.EvalMult(x.data, pt_mask)
+    frame = np.zeros(physical_shape, dtype=logical_values.dtype)
+    frame[tuple(slice(0, size) for size in logical_shape)] = logical_values
 
-            rotation = 1
-            while rotation < target_shape[0]:
-                ct_rotated = cc.EvalRotate(ct_res, -rotation)
-                ct_res = cc.EvalAdd(ct_res, ct_rotated)
-                rotation *= 2
-
-            mask = _create_masking(list(range(target_shape[0])), x.batch_size)
-            pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-            ct_res = cc.EvalMult(ct_res, pt_mask)
-
-            return CTArray(
-                data=ct_res,
-                original_shape=target_shape,
-                batch_size=x.batch_size,
-                new_shape=(next_power_of_two(target_shape[0]),),
-                order=ArrayEncodingType.ROW_MAJOR,
-            )
-
-        # Scalar -> Matrix
-        elif len(target_shape) == 2:
-            nrow, ncol = target_shape
-            mask = _create_masking([0], x.batch_size)
-            pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-            ct_res = cc.EvalMult(x.data, pt_mask)
-
-            if order == ArrayEncodingType.ROW_MAJOR:
-                ncol_pow_2 = next_power_of_two(ncol)
-                mask = [0] * x.batch_size
-                for i in range(nrow):
-                    for j in range(ncol):
-                        mask[i * ncol_pow_2 + j] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = _duplicate_block(ct_res, nrow, ncol_pow_2)
-                ct_res = _duplicate_block(ct_res, ncol, 1, pt_mask)
-
-            elif order == ArrayEncodingType.COL_MAJOR:
-                nrow_pow_2 = next_power_of_two(nrow)
-                mask = [0] * x.batch_size
-                for i in range(ncol):
-                    for j in range(nrow):
-                        mask[i * nrow_pow_2 + j] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = _duplicate_block(ct_res, ncol, nrow_pow_2)
-                ct_res = _duplicate_block(ct_res, nrow, 1, pt_mask)
-
-            else:
-                raise ValueError(f"Invalid order ({order})")
-
-            return CTArray(
-                data=ct_res,
-                original_shape=target_shape,
-                batch_size=x.batch_size,
-                new_shape=(next_power_of_two(nrow), next_power_of_two(ncol)),
-                order=order,
-            )
-
-        raise ValueError(f"Target shape ({target_shape}) is not supported")
-
-    # --- Vector (n,) -> Matrix (m, n) ---
-    if len(x.original_shape) == 1:
-        if len(target_shape) == 2:
-            if target_shape[1] != x.original_shape[0]:
-                raise ValueError(
-                    f"Incompatible shapes: vector length {x.original_shape[0]} "
-                    f"cannot be broadcast to target matrix shape {target_shape}. "
-                    "Only supports broadcasting from (n,) to (m, n)."
-                )
-
-            nrow, ncol = target_shape
-            ncol_pow_2 = next_power_of_two(ncol)
-            nrow_pow_2 = next_power_of_two(nrow)
-
-            if order == ArrayEncodingType.ROW_MAJOR:
-                mask = _create_masking(list(range(x.original_shape[0])), x.batch_size)
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = cc.EvalMult(x.data, pt_mask)
-                ct_res = _duplicate_block(ct_res, nrow, ncol_pow_2)
-
-                return CTArray(
-                    data=ct_res,
-                    original_shape=target_shape,
-                    batch_size=x.batch_size,
-                    new_shape=(nrow_pow_2, ncol_pow_2),
-                    order=order,
-                )
-
-            elif order == ArrayEncodingType.COL_MAJOR:
-                mask = [0] * x.batch_size
-                mask[0] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = cc.EvalMult(x.data, pt_mask)
-
-                for i in range(1, x.original_shape[0]):
-                    mask[i - 1] = 0
-                    mask[i] = 1
-                    pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                    ct_scalar = cc.EvalMult(x.data, pt_mask)
-                    ct_scalar = cc.EvalRotate(ct_scalar, -(nrow_pow_2 * i - i))
-                    ct_res = cc.EvalAdd(ct_res, ct_scalar)
-                mask[x.original_shape[0] - 1] = 0  # reset
-
-                mask = [0] * x.batch_size
-                for i in range(ncol):
-                    for j in range(nrow):
-                        mask[i * nrow_pow_2 + j] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = _duplicate_block(ct_res, nrow, 1, pt_mask)
-
-                return CTArray(
-                    data=ct_res,
-                    original_shape=target_shape,
-                    batch_size=x.batch_size,
-                    new_shape=(nrow_pow_2, ncol_pow_2),
-                    order=order,
-                )
-
-            else:
-                raise ValueError(f"Invalid order ({order})")
-
-    # --- ColVec (m, 1) -> Matrix (m, n) ---
-    elif len(x.original_shape) == 2:
-        if len(target_shape) == 2:
-            try:
-                new_shape = np.broadcast_shapes(x.original_shape, target_shape)
-            except ValueError as e:
-                raise ValueError(
-                    f"Incompatible shapes: {x.original_shape} cannot be broadcast "
-                    f"to target shape {target_shape}. "
-                    "Only supports broadcasting from (m,1) to (m,n) or (1,n) to (m,n) "
-                ) from e
-            nrow, ncol = target_shape
-            ncol_pow_2 = next_power_of_two(ncol)
-            nrow_pow_2 = next_power_of_two(nrow)
-
-            if order == ArrayEncodingType.COL_MAJOR:
-                mask = _create_masking(list(range(nrow)), x.batch_size)
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_x_cleared = cc.EvalMult(x.data, pt_mask)
-                ct_x_duplicated = _duplicate_block(ct_x_cleared, ncol_pow_2, nrow_pow_2)
-
-                return CTArray(
-                    data=ct_x_duplicated,
-                    original_shape=target_shape,
-                    batch_size=x.batch_size,
-                    new_shape=(nrow_pow_2, ncol_pow_2),
-                    order=order,
-                )
-
-            elif order == ArrayEncodingType.ROW_MAJOR:
-                mask = [0] * x.batch_size
-                mask[0] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = cc.EvalMult(x.data, pt_mask)
-
-                for i in range(1, x.original_shape[0]):
-                    mask[i - 1] = 0
-                    mask[i] = 1
-                    pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                    ct_scalar = cc.EvalMult(x.data, pt_mask)
-                    ct_scalar = cc.EvalRotate(ct_scalar, -(ncol_pow_2 * i - i))
-                    ct_res = cc.EvalAdd(ct_res, ct_scalar)
-                mask[x.original_shape[0] - 1] = 0  # reset
-
-                mask = [0] * x.batch_size
-                for i in range(nrow):
-                    for j in range(ncol):
-                        mask[i * ncol_pow_2 + j] = 1
-                pt_mask = cc.MakeCKKSPackedPlaintext(mask)
-                ct_res = _duplicate_block(ct_res, ncol, 1, pt_mask)
-
-                return CTArray(
-                    data=ct_res,
-                    original_shape=target_shape,
-                    batch_size=x.batch_size,
-                    new_shape=(nrow_pow_2, ncol_pow_2),
-                    order=order,
-                )
-
-            else:
-                raise ValueError(f"Invalid order ({order})")
-
-    raise ValueError(
-        f"Incompatible shapes: {x.original_shape} "
-        f"cannot be broadcast to target shape {target_shape}."
+    package = _pack_block(
+        data=frame,
+        original_shape=logical_shape,
+        batch_size=pta_x.batch_size,
+        order=order,
+        mode="zero",
+    )
+    return array(
+        cc=cc,
+        data=frame,
+        batch_size=pta_x.batch_size,
+        order=order,
+        fhe_type="P",
+        package=package,
     )

--- a/openfhe_numpy/operations/dispatch.py
+++ b/openfhe_numpy/operations/dispatch.py
@@ -33,6 +33,8 @@ from typing import Tuple, Callable, Any
 import functools
 import os
 
+from openfhe_numpy.utils.typecheck import is_numeric_scalar
+
 
 # Operation registry - stores implementations keyed by (operation_name, signature)
 TENSOR_FUNCTIONS = {}
@@ -102,8 +104,11 @@ def dispatch_tensor_function(
             print(f"DEBUG: Found exact match! Calling {TENSOR_FUNCTIONS[key]}")
         return TENSOR_FUNCTIONS[key](*args, **kwargs)
 
-    # Step 3: Normalize scalars to 'scalar'
-    normalized_sig = tuple("scalar" if t in {"int", "float", "complex", "bool"} else t for t in sig)
+    # Step 3: Normalize every supported Python/NumPy scalar to 'scalar'.
+    normalized_sig = tuple(
+        "scalar" if is_numeric_scalar(arg) else type_name
+        for arg, type_name in zip(args, sig)
+    )
     key = (func_name, normalized_sig)
     if key in TENSOR_FUNCTIONS:
         return TENSOR_FUNCTIONS[key](*args, **kwargs)

--- a/openfhe_numpy/operations/matrix_api.py
+++ b/openfhe_numpy/operations/matrix_api.py
@@ -332,7 +332,7 @@ def cumulative_reduce(a: ArrayLike, axis: int = 0, keepdims: bool = False) -> Ar
 
 @tensor_function_api("sum", binary=False)
 def sum(a: ArrayLike, /, *, axis: Optional[int] = None, keepdims: bool = False) -> ArrayLike:
-   """
+    """
     Sum of elements over an axis or all.
 
     Parameters

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -53,14 +53,16 @@ from openfhe_numpy.utils.errors import (
     ONPValueError,
     ONPDimensionError,
 )
-from openfhe_numpy.utils.typecheck import is_numeric_scalar
 from openfhe_numpy.openfhe_numpy import (
     ArrayEncodingType,
     EvalMatMulSquare,
     EvalReduceCumRows,
     EvalReduceCumCols,
 )
-from openfhe_numpy.operations.broadcast import broadcast_to
+from openfhe_numpy.operations.arithmetic_utils import (
+    _eval_binary,
+    _eval_scalar_binary,
+)
 
 
 ##############################################################################
@@ -71,148 +73,56 @@ from openfhe_numpy.operations.broadcast import broadcast_to
 # ------------------------------------------------------------------------------
 # Addition Operations
 # ------------------------------------------------------------------------------
-def _eval_add(lhs, rhs):
-    """Internal function to evaluate addition between encrypted tensors."""
-    crypto_context = lhs.data.GetCryptoContext()
-    result = crypto_context.EvalAdd(lhs.data, rhs.data)
-    return CTArray(result, lhs.original_shape, lhs.batch_size, lhs.shape, lhs.order)
-
-
 @register_tensor_function("add", [("CTArray", "CTArray"), ("CTArray", "PTArray")])
 def add_ct(a, b):
     """Add two tensors."""
-    if a.shape == ():
-        return _eval_add(b, a)
-    elif b.shape == ():
-        return _eval_add(a, b)
-    elif a.shape == b.shape:
-        return _eval_add(a, b)
-    else:
-        output_shape = np.broadcast_shapes(a.original_shape, b.original_shape)
-        if a.is_encrypted:
-            crypto_context = a.data.GetCryptoContext()
-        elif b.is_encrypted:
-            crypto_context = b.data.GetCryptoContext()
-        else:
-            raise ValueError(f"This function needs at least one parameter to be encrypted.")
-        if a.original_shape != output_shape:
-            a = broadcast_to(a, output_shape, a.order, crypto_context)
-        else:
-            b = broadcast_to(b, output_shape, b.order, crypto_context)
-        return _eval_add(a, b)
+    return _eval_binary(a, b, "add")
 
 
 @register_tensor_function("add", ("CTArray", "scalar"))
 def add_cta_scalar(a, scalar):
-    """Add a scalar to a x."""
-    crypto_context = a.data.GetCryptoContext()
-    result = crypto_context.EvalAdd(a.data, scalar)
-    return CTArray(result, a.original_shape, a.batch_size, a.shape, a.order)
+    """Add a scalar to an encrypted tensor's logical slots."""
+    return _eval_scalar_binary(a, scalar, "add")
 
 
 # ------------------------------------------------------------------------------
 # Subtraction Operations
 # ------------------------------------------------------------------------------
-def _eval_sub(lhs, rhs):
-    """Internal function to evaluate subtraction between encrypted tensors."""
-
-    crypto_context = (
-        rhs.data.GetCryptoContext() if rhs.dtype == "CTArray" else lhs.data.GetCryptoContext()
-    )
-
-    if isinstance(rhs, (int, float)):
-        rhs = crypto_context.MakeCKKSPackedPlaintext([rhs] * lhs.batch_size)
-    else:
-        rhs = rhs.data
-
-    result = crypto_context.EvalSub(lhs.data, rhs)
-    return CTArray(result, lhs.original_shape, lhs.batch_size, lhs.shape, lhs.order)
-
-
 @register_tensor_function(
     "subtract",
     [("CTArray", "CTArray"), ("CTArray", "PTArray"), ("PTArray", "CTArray")],
 )
 def subtract_ct(a, b):
     """Subtract two tensors."""
-    if a.shape == b.shape:
-        return _eval_sub(a, b)
-    else:
-        output_shape = np.broadcast_shapes(a.original_shape, b.original_shape)
-
-        if a.is_encrypted:
-            crypto_context = a.data.GetCryptoContext()
-        elif b.is_encrypted:
-            crypto_context = b.data.GetCryptoContext()
-        else:
-            raise ValueError(f"This function needs at least one parameter to be encrypted.")
-        if a.original_shape != output_shape:
-            a = broadcast_to(a, output_shape, a.order, crypto_context)
-        else:
-            b = broadcast_to(b, output_shape, b.order, crypto_context)
-
-        return _eval_sub(a, b)
+    return _eval_binary(a, b, "subtract")
 
 
 @register_tensor_function("subtract", [("CTArray", "scalar")])
 def subtract_ct_scalar(a, scalar):
-    crypto_context = a.data.GetCryptoContext()
-    result = crypto_context.EvalSub(a.data, scalar)
-    return a.clone(result)
+    return _eval_scalar_binary(a, scalar, "subtract")
 
 
 @register_tensor_function("subtract", [("scalar", "CTArray")])
 def subtract_scalar_ct(scalar, a):
-    crypto_context = a.data.GetCryptoContext()
-    result = crypto_context.EvalSub(scalar, a.data)
-    return a.clone(result)
+    return _eval_scalar_binary(a, scalar, "subtract", reverse=True)
 
 
 # ------------------------------------------------------------------------------
 # Multiplication Operations
 # ------------------------------------------------------------------------------
-def _eval_multiply(lhs, rhs):
-    """Internal function to evaluate element-wise multiplication."""
-    crypto_context = lhs.data.GetCryptoContext()
-    if is_numeric_scalar(rhs):
-        rhs_data = crypto_context.MakeCKKSPackedPlaintext([rhs] * lhs.batch_size)
-    else:
-        rhs_data = rhs.data
-
-    result = crypto_context.EvalMult(lhs.data, rhs_data)
-    return lhs.clone(result)
-
-
 @register_tensor_function(
     "multiply",
-    [("CTArray", "CTArray"), ("CTArray", "int"), ("CTArray", "PTArray")],
+    [("CTArray", "CTArray"), ("CTArray", "PTArray")],
 )
 def multiply_ct(a, b):
     """Multiply two tensors element-wise."""
-    if is_numeric_scalar(a) or is_numeric_scalar(b):
-        return _eval_multiply(a, b)
-    elif a.shape == b.shape:
-        return _eval_multiply(a, b)
-    else:
-        output_shape = np.broadcast_shapes(a.original_shape, b.original_shape)
-        if a.is_encrypted:
-            crypto_context = a.data.GetCryptoContext()
-        elif b.is_encrypted:
-            crypto_context = b.data.GetCryptoContext()
-        else:
-            raise ValueError(f"This function needs at least one parameter to be encrypted.")
-        if a.original_shape != output_shape:
-            a = broadcast_to(a, output_shape, a.order, crypto_context)
-        else:
-            b = broadcast_to(b, output_shape, b.order, crypto_context)
-
-        return _eval_multiply(a, b)
+    return _eval_binary(a, b, "multiply")
 
 
 @register_tensor_function("multiply", ("CTArray", "scalar"))
 def multiply_ct_scalar(a, scalar):
     """Multiply a tensor by a scalar."""
-    return _eval_multiply(a, scalar)
+    return _eval_scalar_binary(a, scalar, "multiply")
 
 
 ##############################################################################

--- a/openfhe_numpy/tensor/block_tensor.py
+++ b/openfhe_numpy/tensor/block_tensor.py
@@ -89,6 +89,8 @@ class BlockFHETensor(BaseTensor, Generic[TPL]):
     """
 
     tensor_priority = 30
+    # Ensure NumPy scalar operators defer to the tensor reverse operators.
+    __array_priority__ = 1000
     is_encrypted: bool = False
     __hash__ = None
 

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -120,6 +120,9 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         Packing order: only support row-major or column-major.
     """
 
+    # Ensure NumPy scalar operators defer to the tensor reverse operators.
+    __array_priority__ = 1000
+
     __slots__ = (
         "_data",
         "_original_shape",

--- a/openfhe_numpy/utils/_helper_slots_ops.py
+++ b/openfhe_numpy/utils/_helper_slots_ops.py
@@ -1,4 +1,4 @@
-import openfhe
+from operator import index as operator_index
 
 
 def _create_masking(indices, size):
@@ -26,21 +26,33 @@ def _get_single_element(cc, x, idx, batch_size):
     return ct_res
 
 
-def _duplicate_block(x, duplicate_count, block_size, pt_mask=None):
-    """
-    Duplicates a block of 'block_size' slots 'duplicate_count' times.
+def _replication_steps(copies: int, stride: int):
+    """Yield ``(rotation, use_seed)`` for exactly ``copies`` patterns."""
+    copies = operator_index(copies)
+    stride = operator_index(stride)
 
-    """
-    cc = x.GetCryptoContext()
-    rotation = block_size
-    ct_res = x
+    if copies < 1:
+        raise ValueError(f"copies must be positive, got {copies!r}")
+    if stride < 1:
+        raise ValueError(f"stride must be positive, got {stride!r}")
 
-    while rotation < block_size * duplicate_count:
-        ct_rotated = cc.EvalRotate(ct_res, -rotation)
-        ct_res = cc.EvalAdd(ct_res, ct_rotated)
-        rotation *= 2
+    produced = 1
+    for bit in bin(copies)[3:]:
+        yield -(produced * stride), False
+        produced *= 2
 
-    # mask out if needed
-    if pt_mask is not None:
-        ct_res = cc.EvalMult(pt_mask, ct_res)
-    return ct_res
+        if bit == "1":
+            yield -(produced * stride), True
+            produced += 1
+
+
+def _replicate_pattern(seed, copies: int, stride: int):
+    """Replicate an isolated slot pattern exactly ``copies`` times."""
+    cc = seed.GetCryptoContext()
+    result = seed
+
+    for rotation, use_seed in _replication_steps(copies, stride):
+        operand = seed if use_seed else result
+        result = cc.EvalAdd(result, cc.EvalRotate(operand, rotation))
+
+    return result

--- a/openfhe_numpy/utils/errors.py
+++ b/openfhe_numpy/utils/errors.py
@@ -76,7 +76,7 @@ import logging
 import os
 import warnings
 from logging.handlers import RotatingFileHandler
-from typing import Optional
+from typing import Any, Optional
 
 
 # =============================================================================
@@ -229,6 +229,29 @@ class ONPNotSupportedError(ONPError, NotImplementedError):
 
     def __init__(self, message: str = "This feature is not supported.") -> None:
         super().__init__(message)
+
+
+# =============================================================================
+# Validation helper
+# =============================================================================
+
+
+def _require(
+    condition: bool,
+    left: Any,
+    right: Any,
+    message: str,
+    *,
+    error_cls: type[Exception] = ONPIncompatibleShapeError,
+) -> None:
+    """Raise ``error_cls`` when ``condition`` is false."""
+    if condition:
+        return
+
+    if error_cls is ONPIncompatibleShapeError:
+        raise ONPIncompatibleShapeError(left, right, message)
+
+    raise error_cls(message)
 
 
 # =============================================================================

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -421,11 +421,12 @@ def _pack_matrix_col_wise(
     flat_array = np.zeros(batch_size)
     index = 0
 
-    for c in range(ncols):
-        for r in range(nrows):
-            if r < rows and c < cols:
-                flat_array[index] = matrix[r][c]
-            index += 1
+    for _ in range(tiles):
+        for c in range(ncols):
+            for r in range(nrows):
+                if r < rows and c < cols:
+                    flat_array[index] = matrix[r][c]
+                index += 1
 
     return flat_array, shape
 


### PR DESCRIPTION
#Summary

Fixes #87 by preventing broadcasting and scalar arithmetic from polluting CKKS padding and unused batch slots.

#Changes

- Added exact non-power-of-two slot replication with matching runtime and rotation-key schedules.
- Updated direct CT/PT broadcasting for scalar, row, column, row-major, and column-major layouts.
- Preserved true logical shapes for partial block edges while keeping physical padding zero.
- Aligned binary operands from their logical NumPy shapes before comparing physical layouts.
- Added two-sided `(m, 1)` and `(1, n)` broadcasting.
- Rejected incompatible shapes, packing orders, batch sizes, crypto contexts, and key tags.
- Fixed Python and NumPy scalar dispatch.
- Restricted scalar addition and subtraction to logical slots, leaving padding and the batch tail zero.
- Shared packed arithmetic evaluation between direct and block operations.
- Preserved result metadata and standardized typed broadcast errors.
- Removed the previous power-of-two-only replication behavior.

#Remark

Public broadcasting APIs remain unchanged.