### PR TITLE
Fix #85: Correct cumulative sums for packed and block tensors

### DIFF
--- a/openfhe_numpy/cpp/include/numpy_enc_matrix.h
+++ b/openfhe_numpy/cpp/include/numpy_enc_matrix.h
@@ -129,6 +129,17 @@ Ciphertext<DCRTPoly> EvalSumCumCols(ConstCiphertext<DCRTPoly>& ciphertext,
                                           uint32_t numCols,
                                           uint32_t subringDim = 0);
 
+Ciphertext<DCRTPoly> EvalCumSum(
+    ConstCiphertext<DCRTPoly>& ciphertext,
+    uint32_t numFrameRows,
+    uint32_t numFrameCols,
+    uint32_t numActiveRows,
+    uint32_t numParticipatingCols,
+    uint32_t numRepeats,
+    uint32_t axis,
+    ArrayEncodingType order,
+    uint32_t slots);
+
 Ciphertext<DCRTPoly> EvalReduceCumRows(ConstCiphertext<DCRTPoly>& ciphertext,
                                           uint32_t numCols,
                                           uint32_t numRows = 0,

--- a/openfhe_numpy/cpp/lib/numpy_bindings.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_bindings.cpp
@@ -283,6 +283,38 @@ void bind_matrix_funcs(py::module& m) {
         py::arg("numCols"),
         py::arg("subringDim") = 0);
 
+    m.def(
+        "EvalCumSum",
+        [](ConstCiphertext<DCRTPoly>& ciphertext,
+           uint32_t numFrameRows,
+           uint32_t numFrameCols,
+           uint32_t numActiveRows,
+           uint32_t numParticipatingCols,
+           uint32_t numRepeats,
+           uint32_t axis,
+           ArrayEncodingType order,
+           uint32_t slots) {
+            return EvalCumSum(
+                ciphertext,
+                numFrameRows,
+                numFrameCols,
+                numActiveRows,
+                numParticipatingCols,
+                numRepeats,
+                axis,
+                order,
+                slots);
+        },
+        py::arg("ciphertext"),
+        py::arg("numFrameRows"),
+        py::arg("numFrameCols"),
+        py::arg("numActiveRows"),
+        py::arg("numParticipatingCols"),
+        py::arg("numRepeats"),
+        py::arg("axis"),
+        py::arg("order"),
+        py::arg("slots"));
+
     m.def("EvalReduceCumRows",
         [](ConstCiphertext<DCRTPoly>& ciphertext, uint32_t numCols, uint32_t numRows, uint32_t slots) {
             return EvalReduceCumRows(ciphertext, numCols, numRows, slots);

--- a/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
@@ -38,6 +38,47 @@ using namespace lbcrypto;
 
 namespace openfhe_numpy {
 
+namespace {
+
+std::vector<double> GenCumsumStageMask(
+    uint32_t numFrameRows,
+    uint32_t numFrameCols,
+    uint32_t numActiveRows,
+    uint32_t numParticipatingCols,
+    uint32_t numRepeats,
+    uint32_t axis,
+    uint32_t offset,
+    ArrayEncodingType order,
+    uint32_t slots) {
+    std::vector<double> mask(slots, 0.0);
+    const uint64_t frameSize =
+        static_cast<uint64_t>(numFrameRows) * numFrameCols;
+
+    for (uint32_t frame = 0; frame < numRepeats; ++frame) {
+        const uint64_t base = static_cast<uint64_t>(frame) * frameSize;
+        for (uint32_t row = 0; row < numActiveRows; ++row) {
+            for (uint32_t col = 0; col < numParticipatingCols; ++col) {
+                const uint32_t coordinate = axis == 0 ? row : col;
+                if (coordinate < offset) {
+                    continue;
+                }
+                const uint64_t index =
+                    order == ArrayEncodingType::ROW_MAJOR
+                        ? base + static_cast<uint64_t>(row) * numFrameCols + col
+                        : base + static_cast<uint64_t>(col) * numFrameRows + row;
+                if (index >= slots) {
+                    OPENFHE_THROW(
+                        "GenCumsumStageMask generated an invalid slot index.");
+                }
+                mask[static_cast<size_t>(index)] = 1.0;
+            }
+        }
+    }
+    return mask;
+}
+
+}  // namespace
+
 /**
 * @brief Generate rotation indices required for linear transformation based on transformation
 * type.
@@ -908,6 +949,120 @@ Ciphertext<DCRTPoly> EvalSumCumRows(ConstCiphertext<DCRTPoly>& ciphertext,
     }
     return ctSum;
 };
+
+Ciphertext<DCRTPoly> EvalCumSum(
+    ConstCiphertext<DCRTPoly>& ciphertext,
+    uint32_t numFrameRows,
+    uint32_t numFrameCols,
+    uint32_t numActiveRows,
+    uint32_t numParticipatingCols,
+    uint32_t numRepeats,
+    uint32_t axis,
+    ArrayEncodingType order,
+    uint32_t slots) {
+    if (!ciphertext) {
+        OPENFHE_THROW("EvalCumSum received a null ciphertext.");
+    }
+    const auto cc = ciphertext->GetCryptoContext();
+    if (!cc) {
+        OPENFHE_THROW("EvalCumSum received a ciphertext without a context.");
+    }
+    const auto cryptoParams = std::dynamic_pointer_cast<CryptoParametersRNS>(
+        ciphertext->GetCryptoParameters());
+    if (!cryptoParams) {
+        OPENFHE_THROW("EvalCumSum requires CKKS RNS crypto parameters.");
+    }
+    if (ciphertext->GetEncodingType() != CKKS_PACKED_ENCODING) {
+        OPENFHE_THROW("EvalCumSum supports only CKKS packed encoding.");
+    }
+    if (numFrameRows == 0 || numFrameCols == 0 ||
+        numActiveRows == 0 || numParticipatingCols == 0 ||
+        numRepeats == 0 || slots == 0) {
+        OPENFHE_THROW("EvalCumSum geometry and slots must be positive.");
+    }
+    if (numActiveRows > numFrameRows) {
+        OPENFHE_THROW("numActiveRows exceeds numFrameRows.");
+    }
+    if (numParticipatingCols > numFrameCols) {
+        OPENFHE_THROW("numParticipatingCols exceeds numFrameCols.");
+    }
+    if (axis > 1) {
+        OPENFHE_THROW("EvalCumSum axis must be 0 or 1.");
+    }
+    if (order != ArrayEncodingType::ROW_MAJOR &&
+        order != ArrayEncodingType::COL_MAJOR) {
+        OPENFHE_THROW("EvalCumSum supports ROW_MAJOR and COL_MAJOR only.");
+    }
+
+    const uint64_t frameSize =
+        static_cast<uint64_t>(numFrameRows) * numFrameCols;
+    if (frameSize > slots || numRepeats > slots / frameSize) {
+        OPENFHE_THROW("Repeated cumsum frames exceed slots.");
+    }
+
+    const uint32_t length =
+        axis == 0 ? numActiveRows : numParticipatingCols;
+    const uint32_t stride =
+        order == ArrayEncodingType::ROW_MAJOR
+            ? (axis == 0 ? numFrameCols : 1)
+            : (axis == 0 ? 1 : numFrameRows);
+
+    const uint64_t largestRotation =
+        static_cast<uint64_t>(length - 1) * stride;
+    if (largestRotation >
+        static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+        OPENFHE_THROW("EvalCumSum rotation exceeds int32_t.");
+    }
+
+    if (length == 1) {
+        return ciphertext->Clone();
+    }
+
+    const bool fixedManual =
+        cryptoParams->GetScalingTechnique() == FIXEDMANUAL;
+    auto result = ciphertext->Clone();
+    if (fixedManual) {
+        if (result->GetNoiseScaleDeg() < 1) {
+            OPENFHE_THROW("EvalCumSum received an invalid noise-scale degree.");
+        }
+        while (result->GetNoiseScaleDeg() > 1) {
+            cc->ModReduceInPlace(result);
+        }
+    }
+    for (uint32_t offset = 1; offset < length;) {
+        auto mask = GenCumsumStageMask(
+            numFrameRows,
+            numFrameCols,
+            numActiveRows,
+            numParticipatingCols,
+            numRepeats,
+            axis,
+            offset,
+            order,
+            slots);
+
+        const int32_t rotation = -static_cast<int32_t>(
+            static_cast<uint64_t>(offset) * stride);
+        auto rotated = cc->EvalRotate(result, rotation);
+        auto plaintextMask = cc->MakeCKKSPackedPlaintext(
+            mask, 1, result->GetLevel(), nullptr, slots);
+        auto contribution = cc->EvalMult(rotated, plaintextMask);
+        if (fixedManual) {
+            auto alignedResult = cc->EvalMult(result, 1.0);
+            cc->ModReduceInPlace(alignedResult);
+            cc->ModReduceInPlace(contribution);
+            result = alignedResult;
+        }
+        cc->EvalAddInPlace(result, contribution);
+
+        if (offset > length / 2) {
+            break;
+        }
+        offset <<= 1;
+    }
+
+    return result;
+}
 
 Ciphertext<DCRTPoly> EvalReduceCumRows(ConstCiphertext<DCRTPoly>& ciphertext,
                                       uint32_t numCols,

--- a/openfhe_numpy/operations/__init__.py
+++ b/openfhe_numpy/operations/__init__.py
@@ -55,6 +55,7 @@ from .matrix_api import (
 
 from . import matrix_arithmetic
 from . import block_arithmetic
+from . import block_cumsum
 
 # Import crypto context utilities
 from .crypto_helper import (
@@ -75,6 +76,7 @@ from .crypto_helper import (
 )
 
 from .block_broadcast import generate_block_broadcast_key
+from .block_cumsum import gen_cumsum_key, gen_block_cumsum_keys
 
 
 # Define public API
@@ -102,6 +104,8 @@ __all__ = [
     "gen_square_matmult_key",
     "gen_accumulate_rows_key",
     "gen_accumulate_cols_key",
+    "gen_cumsum_key",
+    "gen_block_cumsum_keys",
     # broadcasting operations
     "broadcast_to",
     "generate_broadcast_key",

--- a/openfhe_numpy/operations/arithmetic_utils.py
+++ b/openfhe_numpy/operations/arithmetic_utils.py
@@ -36,6 +36,7 @@ tensor operations.
 
 from __future__ import annotations
 
+from operator import index as operator_index
 from typing import Any
 
 import numpy as np
@@ -47,6 +48,7 @@ from openfhe_numpy.utils.errors import (
     ONPDimensionError,
     ONPIncompatibleShapeError,
     ONPNotImplementedError,
+    ONPNotSupportedError,
     ONPValueError,
     _require,
 )
@@ -110,29 +112,59 @@ def _get_matvec_key_name(matrix_order: Any) -> str:
 # ------------------------------------------------------------------------------
 
 
-def _normalize_axis(axis, ndim: int) -> int:
-    """Normalize integer axis.
+_AXIS_SUPPORT = {
+    "cumsum": frozenset({"none", "integer"}),
+    "sum": frozenset({"none", "integer"}),
+    "mean": frozenset({"none", "integer"}),
+    "roll": frozenset({"none"}),
+    "cumulative_reduce": frozenset({"integer"}),
+}
 
-    Tuple axes and NumPy integer types are not supported.
+
+def _normalize_axis(
+    operation: str,
+    axis,
+    ndim: int,
+) -> int | None:
+    """Validate and normalize an axis for one registered operation.
+
+    Axis tuples are intentionally rejected until multi-axis runtimes exist.
     """
-    if type(axis) is not int:
-        raise ONPDimensionError(f"axis must be an integer, got {type(axis).__name__}.")
+    try:
+        supported = _AXIS_SUPPORT[operation]
+    except KeyError as exc:
+        raise ValueError(f"unknown axis operation {operation!r}.") from exc
+
+    if axis is None:
+        if "none" in supported:
+            return None
+        raise TypeError(f"{operation} requires an integer axis.")
+
+    if isinstance(axis, tuple):
+        if "tuple" not in supported:
+            raise ONPNotSupportedError(
+                f"{operation} does not support tuple axes."
+            )
+        raise ONPNotImplementedError(
+            f"tuple-axis normalization is not implemented for {operation}."
+        )
+
+    if "integer" not in supported:
+        raise ONPNotSupportedError(
+            f"{operation} currently supports only axis=None."
+        )
+
+    if isinstance(axis, (bool, np.bool_)):
+        raise TypeError("axis must be an integer, not boolean.")
+    try:
+        axis = operator_index(axis)
+    except TypeError as exc:
+        raise TypeError(f"axis must be an integer, got {type(axis).__name__}.") from exc
 
     if axis < -ndim or axis >= ndim:
         raise ONPDimensionError(f"axis {axis} is out of bounds for tensor with {ndim} dimensions.")
 
     return axis + ndim if axis < 0 else axis
-
-
-def _normalize_sum_axis(axis, ndim: int) -> int | None:
-    """Normalize a single reduction axis or None.
-
-    Tuple axes are not supported.
-    """
-    if axis is None:
-        return None
-
-    return _normalize_axis(axis, ndim)
 
 
 # ------------------------------------------------------------------------------
@@ -301,7 +333,8 @@ def _logical_slot_indices(tensor):
     -------
     list[int]
         Active slot indices in the tensor's packing order. Physical padding and
-        the batch tail are excluded; replicated vector lanes are included.
+        the batch tail are excluded; replicated vector lanes and repeated
+        frames are included.
 
     Raises
     ------
@@ -312,53 +345,74 @@ def _logical_slot_indices(tensor):
         unsupported.
     """
     logical_shape = tuple(tensor.original_shape)
-    if len(logical_shape) == 0:
-        return [0]
-
     physical_shape = tuple(tensor.shape)
-    if len(logical_shape) == 1:
+
+    if len(logical_shape) == 0:
+        frame_indices = [0]
+    elif len(logical_shape) == 1:
         logical_length = logical_shape[0]
         if len(physical_shape) == 1 or physical_shape[1] == 1:
-            return list(range(logical_length))
+            frame_indices = list(range(logical_length))
+        else:
+            physical_rows, physical_cols = physical_shape
+            if logical_length > physical_rows:
+                raise ONPValueError(
+                    f"logical shape {logical_shape} exceeds physical frame {tensor.shape}."
+                )
 
+            participating_cols = physical_cols
+            if tensor.geometry is not None and tensor.geometry.padding == "zero":
+                participating_cols = tensor.geometry.active[1]
+
+            if tensor.order == ArrayEncodingType.ROW_MAJOR:
+                frame_indices = [
+                    row * physical_cols + col
+                    for row in range(logical_length)
+                    for col in range(participating_cols)
+                ]
+            elif tensor.order == ArrayEncodingType.COL_MAJOR:
+                frame_indices = [
+                    col * physical_rows + row
+                    for col in range(participating_cols)
+                    for row in range(logical_length)
+                ]
+            else:
+                raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
+    else:
+        if len(logical_shape) != 2 or len(physical_shape) != 2:
+            raise ONPDimensionError(
+                f"Scalar arithmetic supports logical rank zero, one, or two; got {logical_shape}."
+            )
+
+        logical_rows, logical_cols = logical_shape
         physical_rows, physical_cols = physical_shape
-        if logical_length > physical_rows:
+        if logical_rows > physical_rows or logical_cols > physical_cols:
             raise ONPValueError(
                 f"logical shape {logical_shape} exceeds physical frame {tensor.shape}."
             )
+
         if tensor.order == ArrayEncodingType.ROW_MAJOR:
-            return [
+            frame_indices = [
                 row * physical_cols + col
-                for row in range(logical_length)
-                for col in range(physical_cols)
+                for row in range(logical_rows)
+                for col in range(logical_cols)
             ]
-        if tensor.order == ArrayEncodingType.COL_MAJOR:
-            return [
+        elif tensor.order == ArrayEncodingType.COL_MAJOR:
+            frame_indices = [
                 col * physical_rows + row
-                for col in range(physical_cols)
-                for row in range(logical_length)
+                for col in range(logical_cols)
+                for row in range(logical_rows)
             ]
-        raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
+        else:
+            raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
 
-    if len(logical_shape) != 2 or len(physical_shape) != 2:
-        raise ONPDimensionError(
-            f"Scalar arithmetic supports logical rank zero, one, or two; got {logical_shape}."
-        )
-
-    logical_rows, logical_cols = logical_shape
-    physical_rows, physical_cols = physical_shape
-    if logical_rows > physical_rows or logical_cols > physical_cols:
-        raise ONPValueError(f"logical shape {logical_shape} exceeds physical frame {tensor.shape}.")
-
-    if tensor.order == ArrayEncodingType.ROW_MAJOR:
-        return [
-            row * physical_cols + col for row in range(logical_rows) for col in range(logical_cols)
-        ]
-    if tensor.order == ArrayEncodingType.COL_MAJOR:
-        return [
-            col * physical_rows + row for col in range(logical_cols) for row in range(logical_rows)
-        ]
-    raise ONPValueError(f"Unsupported packing order {tensor.order!r}.")
+    frame_size = int(np.prod(physical_shape))
+    repeats = 1 if tensor.geometry is None else tensor.geometry.repeats
+    return [
+        repeat_idx * frame_size + frame_idx
+        for repeat_idx in range(repeats)
+        for frame_idx in frame_indices
+    ]
 
 
 def _logical_plaintext(tensor, value, indices):

--- a/openfhe_numpy/operations/block_arithmetic.py
+++ b/openfhe_numpy/operations/block_arithmetic.py
@@ -60,7 +60,7 @@ from .matrix_arithmetic import (
     _reduce_ct,
     sum_ct,
 )
-from .arithmetic_utils import _normalize_axis, _normalize_sum_axis
+from .arithmetic_utils import _normalize_axis
 from ..utils.matlib import _sum_terms
 
 # ==============================================================================
@@ -207,68 +207,33 @@ def power_block_ct(a, exp):
 
 
 # ------------------------------------------------------------------------------
-# Cumulative Operations
+# Cumulative Reduction Operations
 # ------------------------------------------------------------------------------
 @register_tensor_function(
     "cumsum",
-    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+    [
+        ("BlockCTArray",),
+        ("BlockCTArray", "NoneType"),
+        ("BlockCTArray", "int"),
+        ("BlockCTArray", "scalar"),
+    ],
 )
-def cumsum_block_ct(obj, axis=None, keepdims=False):
-    """Compute cumulative sums for encrypted block tensors.
+def cumsum_block_ct(obj, axis=None):
+    """Compute NumPy-style cumulative sums with exact cross-block carry."""
+    from .block_cumsum import _eval_block_cumsum
 
-    Currently supports:
-    - 1D block tensors across multiple blocks.
-    - 2D block tensors only when the cumulative axis stays inside each block.
-    """
-    if keepdims:
-        raise ONPNotImplementedError("Block cumsum does not support keepdims=True yet.")
-
-    if obj.ndim == 1:
-        if axis is None:
-            axis = 0
-
-        axis = _normalize_axis(axis, obj.ndim)
-
-        blocks = []
-        offset = None
-
-        for block in obj.data:
-            cumulative = block.cumsum(axis=0)
-
-            if offset is not None:
-                cumulative = cumulative + offset
-
-            blocks.append(cumulative)
-
-            block_sum = block.sum()
-            offset = block_sum if offset is None else offset + block_sum
-
-        return obj.clone(data=blocks)
-
-    if obj.ndim == 2:
-        if axis is None:
-            raise ONPNotImplementedError("Block cumsum(axis=None) is not implemented yet.")
-
-        axis = _normalize_axis(axis, obj.ndim)
-
-        if axis == 0 and obj.grid_shape[0] != 1:
-            raise ONPNotImplementedError(
-                "Block cumsum(axis=0) across multiple block rows is not implemented yet."
-            )
-
-        if axis == 1 and obj.grid_shape[1] != 1:
-            raise ONPNotImplementedError(
-                "Block cumsum(axis=1) across multiple block columns is not implemented yet."
-            )
-
-        return obj.clone(data=[block.cumsum(axis=axis) for block in obj.data])
-
-    raise ONPDimensionError(f"cumsum requires 1D or 2D tensor, got {obj.ndim}D.")
+    return _eval_block_cumsum(obj, axis)
 
 
 @register_tensor_function(
     "cumulative_reduce",
-    [("BlockCTArray",), ("BlockCTArray", "int"), ("BlockCTArray", "int", "bool")],
+    [
+        ("BlockCTArray",),
+        ("BlockCTArray", "int"),
+        ("BlockCTArray", "scalar"),
+        ("BlockCTArray", "int", "bool"),
+        ("BlockCTArray", "scalar", "bool"),
+    ],
 )
 def cumulative_reduce_block_ct(a, axis=0, keepdims=False):
     """Compute cumulative reductions inside each encrypted block."""
@@ -278,7 +243,7 @@ def cumulative_reduce_block_ct(a, axis=0, keepdims=False):
     if a.ndim != 2:
         raise ONPDimensionError(f"cumulative_reduce requires a 2D block tensor, got {a.ndim}D.")
 
-    axis = _normalize_axis(axis, a.ndim)
+    axis = _normalize_axis("cumulative_reduce", axis, a.ndim)
 
     if axis == 0 and a.grid_shape[0] != 1:
         raise ONPNotImplementedError(
@@ -305,7 +270,7 @@ def sum_block_ct(x: BlockCTArray, axis: Optional[int] = None, keepdims: bool = F
     if keepdims:
         raise ONPNotImplementedError("Block sum does not support keepdims=True yet.")
 
-    axis = _normalize_sum_axis(axis, x.ndim)
+    axis = _normalize_axis("sum", axis, x.ndim)
 
     if x.ndim == 1:
         return _sum_terms(sum_ct(block, None, False) for block in x.data)
@@ -375,7 +340,7 @@ def mean_block_ct(x: BlockCTArray, axis: Optional[int] = None, keepdims: bool = 
     if keepdims:
         raise ONPNotImplementedError("Block mean does not support keepdims=True yet.")
 
-    axis = _normalize_sum_axis(axis, x.ndim)
+    axis = _normalize_axis("mean", axis, x.ndim)
     mean_x = sum_block_ct(x, axis, keepdims=False)
 
     if x.ndim == 1:

--- a/openfhe_numpy/operations/block_broadcast.py
+++ b/openfhe_numpy/operations/block_broadcast.py
@@ -33,7 +33,7 @@
 
 Broadcasting follows NumPy rules for logical shapes while preserving existing
 block boundaries. Supported sources have shape ``(n,)``, ``(1, n)``, or
-``(m, 1)``. Re-tiling and compact vector packing are not supported, and at least
+``(m, 1)``. Re-tiling and expanded vector frames are not supported, and at least
 one operand must be encrypted.
 
 Use :func:`generate_block_broadcast_key` to generate the required rotation keys.
@@ -95,7 +95,7 @@ def _broadcast_shape(*shapes: tuple[int, ...]) -> tuple[int, ...]:
 
 
 def _is_standard_block_layout(tensor: BlockFHETensor) -> bool:
-    """Check whether a tensor uses standard block packing.
+    """Check whether a tensor uses unexpanded block packing.
 
     Parameters
     ----------
@@ -109,11 +109,10 @@ def _is_standard_block_layout(tensor: BlockFHETensor) -> bool:
 
     Notes
     -----
-    A standard vector block of logical shape ``(b,)`` has physical shape
-    ``(b, 1)``. Compact vector blocks use a square physical layout.
+    An unexpanded vector block of logical shape ``(b,)`` has physical shape
+    ``(b, 1)``. Expanded vector blocks use a wider physical layout.
     """
     block_shape = tensor.block_shape
-    # Standard 1-D packing has physical shape (b, 1); compact packing is square.
     standard = (block_shape[0], 1) if len(block_shape) == 1 else block_shape
     return tuple(tensor.data[0].shape) == standard
 
@@ -266,8 +265,8 @@ def _validate_source_for_layout(
         _is_standard_block_layout(source),
         tuple(source.data[0].shape),
         source.block_shape,
-        "Block broadcasting requires standard non-compact packing; construct "
-        "vector sources with compact=False.",
+        "Block broadcasting requires an unexpanded vector source "
+        "(target_cols=None).",
         error_cls=ONPNotSupportedError,
     )
 
@@ -665,7 +664,7 @@ def generate_block_broadcast_key(secret_key: Any, *operands: BlockFHETensor) -> 
     ONPIncompatibleShapeError
         If operand block shapes are not broadcast-compatible.
     ONPNotSupportedError
-        If an operand has compact packing or an unsupported source shape.
+        If an operand has expanded vector packing or an unsupported source shape.
     ONPValueError
         If no operand is given or the key does not match an encrypted operand.
 
@@ -701,7 +700,7 @@ def generate_block_broadcast_key(secret_key: Any, *operands: BlockFHETensor) -> 
             _is_standard_block_layout(operand),
             tuple(operand.data[0].shape),
             operand.block_shape,
-            "Block broadcast key generation requires standard (non-compact) block layout.",
+            "Block broadcast key generation requires an unexpanded vector layout.",
             error_cls=ONPNotSupportedError,
         )
         _verify_secret_key(secret_key, operand)

--- a/openfhe_numpy/operations/block_cumsum.py
+++ b/openfhe_numpy/operations/block_cumsum.py
@@ -1,0 +1,959 @@
+# ==================================================================================
+#  BSD 2-Clause License
+#
+#  Copyright (c) 2014-2025, NJIT, Duality Technologies Inc. and other contributors
+#
+#  All rights reserved.
+#
+#  Author TPOC: contact@openfhe.org
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice, this
+#     list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ==================================================================================
+
+"""Plan and evaluate NumPy-compatible cumulative sums on encrypted tensors.
+
+The public key-generation functions install the rotation keys needed by one
+``cumsum`` axis and packed layout. The private helpers share the same rotation
+plans with runtime evaluation, validate block geometry, flatten matrix blocks
+in logical C order for ``axis=None``, and propagate cumulative totals between
+ciphertext blocks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from math import isclose, prod
+
+import openfhe
+from openfhe import FIXEDMANUAL
+
+from ..tensor.block_ctarray import BlockCTArray
+from ..tensor.ctarray import CTArray
+from ..tensor.tensor import FramePacking
+from ..utils._helper_slots_ops import (
+    _create_masking,
+    _get_slot_index,
+    _replicate_pattern,
+    _replication_steps,
+)
+from ..utils.errors import ONPValueError, _require
+from ..utils.matlib import next_power_of_two
+from ..utils.packing import _is_col_major, _is_row_major
+from .arithmetic_utils import _normalize_axis
+
+
+# ------------------------------------------------------------------------------
+# Shared cumsum planning and geometry helpers
+# ------------------------------------------------------------------------------
+
+
+def _get_cumsum_lane_parameters(tensor: CTArray, axis: int) -> tuple[int, int, int]:
+    """Return the active length, lane count, and slot stride for one scan axis."""
+    geometry = tensor.geometry
+    _require(
+        geometry is not None,
+        geometry,
+        None,
+        "cumsum requires packed geometry.",
+        error_cls=ONPValueError,
+    )
+
+    frame_rows, frame_cols = tensor.shape
+    active_rows, active_cols = geometry.active
+    _require(
+        _is_row_major(tensor.order) or _is_col_major(tensor.order),
+        tensor.order,
+        None,
+        f"unsupported cumsum packing order {tensor.order!r}.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        geometry.padding in ("tile", "zero"),
+        geometry.padding,
+        ("tile", "zero"),
+        f"unsupported cumsum padding mode {geometry.padding!r}.",
+        error_cls=ONPValueError,
+    )
+
+    if geometry.padding == "tile":
+        scan_cols = frame_cols
+    else:
+        scan_cols = active_cols
+
+    if axis == 0:
+        lane_size = active_rows
+        num_lanes = scan_cols
+        slot_stride = frame_cols if _is_row_major(tensor.order) else 1
+    else:
+        lane_size = scan_cols
+        num_lanes = active_rows
+        slot_stride = 1 if _is_row_major(tensor.order) else frame_rows
+
+    return lane_size, num_lanes, slot_stride
+
+
+def _can_flatten_ctarray_without_slot_moves(tensor: CTArray) -> bool:
+    """Return whether matrix ``axis=None`` can reuse ciphertext slots directly."""
+    geometry = tensor.geometry
+    if tensor.ndim != 2 or geometry is None or not _is_row_major(tensor.order):
+        return False
+
+    frame_rows, frame_cols = tensor.shape
+    active_rows, active_cols = geometry.active
+    return (
+        geometry.padding == "zero"
+        and geometry.active == tuple(tensor.original_shape)
+        and active_rows <= frame_rows
+        and active_cols == frame_cols
+    )
+
+
+def _plan_cumsum_lane_rotations(lane_size: int, slot_stride: int) -> set[int]:
+    """Return rotations for a power-of-two prefix scan over one lane."""
+    rotations = set()
+    offset = 1
+    while offset < lane_size:
+        rotations.add(-(offset * slot_stride))
+        offset *= 2
+    return rotations
+
+
+def _plan_block_matrix_flatten_moves(
+    block_tensor: BlockCTArray,
+) -> tuple[int, int, list[dict[tuple[int, int], list[int]]]]:
+    """Group the mask-and-rotate moves needed for C-order block flattening."""
+    block_rows, block_cols = block_tensor.block_shape
+    block_size = block_rows * block_cols
+    frame_rows = next_power_of_two(block_size)
+    _require(
+        frame_rows <= block_tensor.batch_size,
+        frame_rows,
+        block_tensor.batch_size,
+        "flattened cumsum frame exceeds batch_size.",
+        error_cls=ONPValueError,
+    )
+
+    rows, cols = block_tensor.original_shape
+    _, grid_cols = block_tensor.grid_shape
+    num_chunks = (rows * cols + block_size - 1) // block_size
+    chunks = [{} for _ in range(num_chunks)]
+
+    for block_idx, block in enumerate(block_tensor.data):
+        grid_row, grid_col = divmod(block_idx, grid_cols)
+        active_rows, active_cols = block.geometry.active
+        for cell_row in range(active_rows):
+            row = grid_row * block_rows + cell_row
+            for cell_col in range(active_cols):
+                col = grid_col * block_cols + cell_col
+                logical_idx = row * cols + col
+                chunk_idx, target_slot = divmod(logical_idx, block_size)
+                source_slot = _get_slot_index(
+                    cell_row,
+                    cell_col,
+                    block.shape,
+                    block.order,
+                )
+                rotation = source_slot - target_slot
+                key = block_idx, rotation
+                chunks[chunk_idx].setdefault(key, []).append(source_slot)
+
+    return block_size, frame_rows, chunks
+
+
+def _can_view_block_matrix_as_c_order_vector(block_tensor: BlockCTArray) -> bool:
+    """Return whether block-list order already matches logical C order."""
+    if (
+        block_tensor.ndim != 2
+        or not _is_row_major(block_tensor.order)
+        or block_tensor.grid_shape[1] != 1
+    ):
+        return False
+
+    return all(_can_flatten_ctarray_without_slot_moves(block) for block in block_tensor.data)
+
+
+def _view_block_matrix_as_c_order_vector(block_tensor: BlockCTArray) -> BlockCTArray:
+    """Return a metadata-only vector view that shares the matrix ciphertexts."""
+    blocks = []
+    for block in block_tensor.data:
+        frame_size = prod(block.shape)
+        logical_size = prod(block.original_shape)
+        blocks.append(
+            CTArray(
+                data=block.data,
+                original_shape=(logical_size,),
+                batch_size=block.batch_size,
+                new_shape=(frame_size, 1),
+                order=block.order,
+                geometry=FramePacking(
+                    active=(logical_size, 1),
+                    padding="zero",
+                    repeats=block.geometry.repeats,
+                ),
+            )
+        )
+
+    frame_size = prod(block_tensor.data[0].shape)
+    return BlockCTArray(
+        data=blocks,
+        grid_shape=(len(blocks),),
+        block_shape=(frame_size,),
+        original_shape=(prod(block_tensor.original_shape),),
+        batch_size=block_tensor.batch_size,
+        order=block_tensor.order,
+    )
+
+
+# ------------------------------------------------------------------------------
+# CTArray key generation
+# ------------------------------------------------------------------------------
+
+
+def _plan_ctarray_cumsum_rotations(
+    tensor: CTArray,
+    axis: int | None = None,
+) -> set[int]:
+    """Return every rotation used by ``CTArray.cumsum`` for one axis."""
+    _require(
+        tensor.geometry is not None,
+        tensor.geometry,
+        None,
+        "cumsum requires packed geometry; construct the tensor with array().",
+        error_cls=ONPValueError,
+    )
+    _require(
+        tensor.ndim in (0, 1, 2),
+        tensor.ndim,
+        (0, 1, 2),
+        f"cumsum keys require scalar, vector, or matrix geometry; got {tensor.ndim}D.",
+        error_cls=ONPValueError,
+    )
+
+    axis = _normalize_axis(
+        "cumsum",
+        axis,
+        1 if tensor.ndim <= 1 else tensor.ndim,
+    )
+
+    if tensor.ndim <= 1 and axis is None:
+        axis = 0
+
+    if axis is not None:
+        lane_size, _, slot_stride = _get_cumsum_lane_parameters(
+            tensor,
+            axis,
+        )
+        return _plan_cumsum_lane_rotations(lane_size, slot_stride)
+
+    if _can_flatten_ctarray_without_slot_moves(tensor):
+        return _plan_cumsum_lane_rotations(prod(tensor.original_shape), 1)
+
+    rotations = set()
+    active_rows, active_cols = tensor.geometry.active
+    for row in range(active_rows):
+        for col in range(active_cols):
+            slot = _get_slot_index(
+                row,
+                col,
+                tensor.shape,
+                tensor.order,
+            )
+            if slot:
+                rotations.add(slot)
+    size = active_rows * active_cols
+    rotations.update(-offset for offset in range(1, size))
+    return rotations
+
+
+def gen_cumsum_key(
+    secret_key: openfhe.PrivateKey,
+    tensor: CTArray,
+    axis: int | None = None,
+) -> None:
+    """Install rotation keys required by one ``CTArray.cumsum`` call.
+
+    Parameters
+    ----------
+    secret_key : openfhe.PrivateKey
+        Private key used to install evaluation keys in its crypto context.
+    tensor : CTArray
+        Encrypted tensor whose packed shape, order, and geometry determine the
+        required rotations.
+    axis : int or None, optional
+        Axis that will be passed to ``tensor.cumsum``. For vectors, ``None`` is
+        equivalent to ``0``. For matrices, ``None`` requests logical C-order
+        flattening.
+
+    Returns
+    -------
+    None
+        Keys are stored in the crypto context associated with ``secret_key``.
+
+    Raises
+    ------
+    TypeError
+        If ``axis`` is neither ``None`` nor an integer.
+    ONPDimensionError
+        If ``axis`` is outside the tensor rank.
+    ONPValueError
+        If the arguments have the wrong type, key and tensor do not share a
+        crypto context and key tag, or the packed layout is unsupported.
+
+    Notes
+    -----
+    Rotation keys depend on both ``axis`` and the tensor's packed geometry. Call
+    this after the final layout is known and before evaluating the corresponding
+    cumsum. Scalar inputs and length-one scan lanes may require no rotations.
+    """
+    _require(
+        isinstance(secret_key, openfhe.PrivateKey),
+        type(secret_key),
+        openfhe.PrivateKey,
+        "gen_cumsum_key expects a PrivateKey.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        isinstance(tensor, CTArray),
+        type(tensor),
+        CTArray,
+        "gen_cumsum_key expects a CTArray.",
+        error_cls=ONPValueError,
+    )
+    same_key_domain = (
+        secret_key.GetCryptoContext() == tensor.data.GetCryptoContext()
+        and secret_key.GetKeyTag() == tensor.data.GetKeyTag()
+    )
+    _require(
+        same_key_domain,
+        secret_key,
+        tensor,
+        "secret_key and tensor must share a crypto context and key tag.",
+        error_cls=ONPValueError,
+    )
+    rotations = _plan_ctarray_cumsum_rotations(tensor, axis=axis)
+    if rotations:
+        secret_key.GetCryptoContext().EvalRotateKeyGen(
+            secret_key,
+            sorted(rotations),
+        )
+
+
+# ------------------------------------------------------------------------------
+# BlockCTArray preparation
+# ------------------------------------------------------------------------------
+
+
+def _validate_and_plan_block_cumsum(
+    block_tensor: BlockCTArray,
+    axis: int | None,
+) -> tuple[int | None, tuple[tuple[int, ...], ...]]:
+    """Validate block geometry and return the normalized axis and block chains."""
+    axis = _normalize_axis("cumsum", axis, block_tensor.ndim)
+    if block_tensor.ndim == 1 and axis is None:
+        axis = 0
+
+    if block_tensor.ndim == 1:
+        block_chains = (tuple(range(block_tensor.num_blocks)),)
+    else:
+        grid_rows, grid_cols = block_tensor.grid_shape
+        if axis is None:
+            block_chains = ()
+        elif axis == 0:
+            block_chains = tuple(
+                tuple(grid_row * grid_cols + grid_col for grid_row in range(grid_rows))
+                for grid_col in range(grid_cols)
+            )
+        else:
+            block_chains = tuple(
+                tuple(grid_row * grid_cols + grid_col for grid_col in range(grid_cols))
+                for grid_row in range(grid_rows)
+            )
+
+    ref_block = block_tensor.data[0]
+    ref_geometry = ref_block.geometry
+    _require(
+        ref_geometry is not None,
+        ref_geometry,
+        None,
+        "block child 0 has no packed geometry; construct it with "
+        "block_array() before calling cumsum.",
+        error_cls=ONPValueError,
+    )
+
+    for block_idx, block in enumerate(block_tensor.data):
+        geometry = block.geometry
+        _require(
+            geometry is not None,
+            geometry,
+            None,
+            f"block child {block_idx} has no packed geometry; "
+            "construct it with block_array() before calling cumsum.",
+            error_cls=ONPValueError,
+        )
+
+        frame_rows, frame_cols = block.shape
+        active_rows, active_cols = geometry.active
+        valid = (
+            1 <= active_rows <= frame_rows
+            and 1 <= active_cols <= frame_cols
+            and geometry.repeats >= 1
+            and geometry.repeats * frame_rows * frame_cols <= block.batch_size
+        )
+        _require(
+            valid,
+            geometry,
+            block.shape,
+            f"block child {block_idx} has invalid packed geometry {geometry}.",
+            error_cls=ONPValueError,
+        )
+
+        compatible = (
+            block.shape == ref_block.shape
+            and block.order == block_tensor.order
+            and block.batch_size == block_tensor.batch_size
+            and geometry.padding == ref_geometry.padding
+            and geometry.repeats == ref_geometry.repeats
+            and block.crypto_context == ref_block.crypto_context
+            and block.data.GetKeyTag() == ref_block.data.GetKeyTag()
+        )
+        _require(
+            compatible,
+            block,
+            ref_block,
+            f"incompatible cumsum child {block_idx}; all blocks must share "
+            "one frame shape, order, slot domain, padding mode, repeat count, "
+            "crypto context, and key tag.",
+            error_cls=ONPValueError,
+        )
+
+    if axis is None:
+        _require(
+            ref_block.shape == tuple(block_tensor.block_shape),
+            ref_block.shape,
+            block_tensor.block_shape,
+            "matrix cumsum(axis=None) requires child frame shape to match block_shape.",
+            error_cls=ONPValueError,
+        )
+        return None, ()
+
+    lane_capacity = block_tensor.block_shape[axis]
+
+    for block_chain in block_chains:
+        _, expected_lanes, _ = _get_cumsum_lane_parameters(
+            block_tensor.data[block_chain[0]],
+            axis,
+        )
+        last_idx = block_chain[-1]
+        for block_idx in block_chain:
+            lane_size, num_lanes, _ = _get_cumsum_lane_parameters(
+                block_tensor.data[block_idx],
+                axis,
+            )
+            _require(
+                num_lanes == expected_lanes,
+                num_lanes,
+                expected_lanes,
+                f"incompatible non-axis geometry in cumsum block chain {block_chain}.",
+                error_cls=ONPValueError,
+            )
+            _require(
+                block_idx == last_idx or lane_size == lane_capacity,
+                lane_size,
+                lane_capacity,
+                f"cumsum block chain {block_chain} shrinks before its final child.",
+                error_cls=ONPValueError,
+            )
+            _require(
+                1 <= lane_size <= lane_capacity,
+                lane_size,
+                lane_capacity,
+                f"invalid active cumsum length {lane_size} in child {block_idx}.",
+                error_cls=ONPValueError,
+            )
+
+    return axis, block_chains
+
+
+# ------------------------------------------------------------------------------
+# BlockCTArray key generation
+# ------------------------------------------------------------------------------
+
+
+def _plan_block_cumsum_rotations(
+    block_tensor: BlockCTArray,
+    axis: int | None = None,
+) -> set[int]:
+    """Return every rotation used by block cumsum for one axis and layout."""
+    axis, block_chains = _validate_and_plan_block_cumsum(block_tensor, axis)
+    rotations = set()
+    if axis is None:
+        if _can_view_block_matrix_as_c_order_vector(block_tensor):
+            flattened = _view_block_matrix_as_c_order_vector(block_tensor)
+            return _plan_block_cumsum_rotations(flattened, axis=0)
+
+        block_size, _, chunks = _plan_block_matrix_flatten_moves(block_tensor)
+        rotations.update(rotation for chunk in chunks for _, rotation in chunk if rotation)
+        total_cells = prod(block_tensor.original_shape)
+        for chunk_idx in range(len(chunks)):
+            start = chunk_idx * block_size
+            num_cells = min(block_size, total_cells - start)
+            rotations.update(_plan_cumsum_lane_rotations(num_cells, 1))
+            if chunk_idx < len(chunks) - 1 and num_cells > 1:
+                rotations.add(num_cells - 1)
+            if chunk_idx > 0:
+                rotations.update(rotation for rotation, _ in _replication_steps(num_cells, 1))
+    else:
+        for block_chain in block_chains:
+            for block_idx in block_chain:
+                block = block_tensor.data[block_idx]
+                lane_size, _, slot_stride = _get_cumsum_lane_parameters(
+                    block,
+                    axis,
+                )
+                rotations.update(
+                    _plan_cumsum_lane_rotations(
+                        lane_size,
+                        slot_stride,
+                    )
+                )
+                if block_idx != block_chain[-1]:
+                    total_rotation = (lane_size - 1) * slot_stride
+                    if total_rotation:
+                        rotations.add(total_rotation)
+                if block_idx != block_chain[0]:
+                    rotations.update(
+                        rotation
+                        for rotation, _ in _replication_steps(
+                            lane_size,
+                            slot_stride,
+                        )
+                    )
+
+    rotations.discard(0)
+    return rotations
+
+
+def gen_block_cumsum_keys(
+    secret_key: openfhe.PrivateKey,
+    block_tensor: BlockCTArray,
+    axis: int | None = None,
+) -> None:
+    """Install rotation keys required by one ``BlockCTArray.cumsum`` call.
+
+    Parameters
+    ----------
+    secret_key : openfhe.PrivateKey
+        Private key used to install evaluation keys in its crypto context.
+    block_tensor : BlockCTArray
+        Encrypted block tensor whose child geometry and grid layout determine
+        the required rotations.
+    axis : int or None, optional
+        Axis that will be passed to ``block_tensor.cumsum``. Vector ``None`` is
+        equivalent to ``0``. Matrix ``None`` flattens in logical C order.
+
+    Returns
+    -------
+    None
+        Keys are stored in the crypto context associated with ``secret_key``.
+
+    Raises
+    ------
+    TypeError
+        If ``axis`` is neither ``None`` nor an integer.
+    ONPDimensionError
+        If ``axis`` is outside the tensor rank.
+    ONPValueError
+        If arguments have the wrong type, the tensor is empty or unsupported,
+        child geometry is incompatible, or key and ciphertexts do not share a
+        crypto context and key tag.
+
+    Notes
+    -----
+    The installed set covers local prefix scans, movement of each block's
+    terminal values, replication of accumulated carry into following blocks,
+    and matrix-flattening moves when ``axis=None``. Generate keys after the
+    block layout is final and for the same axis used at evaluation time.
+    """
+    _require(
+        isinstance(secret_key, openfhe.PrivateKey),
+        type(secret_key),
+        openfhe.PrivateKey,
+        "gen_block_cumsum_keys expects a PrivateKey.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        isinstance(block_tensor, BlockCTArray),
+        type(block_tensor),
+        BlockCTArray,
+        "gen_block_cumsum_keys expects a BlockCTArray.",
+        error_cls=ONPValueError,
+    )
+    _require(
+        block_tensor.ndim in (1, 2) and bool(block_tensor.data),
+        block_tensor.ndim,
+        (1, 2),
+        "gen_block_cumsum_keys expects a nonempty block vector or matrix.",
+        error_cls=ONPValueError,
+    )
+
+    rotations = _plan_block_cumsum_rotations(block_tensor, axis)
+    ref_block = block_tensor.data[0]
+    same_key_domain = (
+        secret_key.GetCryptoContext() == ref_block.data.GetCryptoContext()
+        and secret_key.GetKeyTag() == ref_block.data.GetKeyTag()
+    )
+    _require(
+        same_key_domain,
+        secret_key,
+        ref_block,
+        "secret_key and every child must share a context and key tag.",
+        error_cls=ONPValueError,
+    )
+
+    if rotations:
+        secret_key.GetCryptoContext().EvalRotateKeyGen(
+            secret_key,
+            sorted(rotations),
+        )
+
+
+# ------------------------------------------------------------------------------
+# CKKS level and scale alignment
+# ------------------------------------------------------------------------------
+
+
+def _advance_ciphertext_to_level(
+    cc: openfhe.CryptoContext,
+    ct: openfhe.Ciphertext,
+    target_level: int,
+) -> openfhe.Ciphertext:
+    """Advance a ciphertext to ``target_level`` without changing its value."""
+    result = ct
+    fixed_manual = cc.GetScalingTechnique() == FIXEDMANUAL
+    while result.GetLevel() < target_level:
+        result = cc.EvalMult(result, 1.0)
+        if fixed_manual:
+            cc.ModReduceInPlace(result)
+    return result
+
+
+def _prepare_ciphertexts_for_addition(
+    cc: openfhe.CryptoContext,
+    lhs: openfhe.Ciphertext,
+    rhs: openfhe.Ciphertext,
+) -> tuple[openfhe.Ciphertext, openfhe.Ciphertext]:
+    """Prepare ciphertext levels and scales for addition under ``FIXEDMANUAL``."""
+    if cc.GetScalingTechnique() != FIXEDMANUAL:
+        return lhs, rhs
+
+    if (
+        lhs.GetLevel() == rhs.GetLevel()
+        and lhs.GetNoiseScaleDeg() == 1
+        and rhs.GetNoiseScaleDeg() == 1
+        and isclose(
+            lhs.GetScalingFactor(),
+            rhs.GetScalingFactor(),
+            rel_tol=1e-10,
+            abs_tol=0.0,
+        )
+    ):
+        return lhs, rhs
+
+    def normalize_scale(ct):
+        result = ct.Clone()
+        while result.GetNoiseScaleDeg() > 1:
+            cc.ModReduceInPlace(result)
+        return result
+
+    lhs = normalize_scale(lhs)
+    rhs = normalize_scale(rhs)
+    target_level = max(lhs.GetLevel(), rhs.GetLevel())
+    lhs = _advance_ciphertext_to_level(cc, lhs, target_level)
+    rhs = _advance_ciphertext_to_level(cc, rhs, target_level)
+
+    _require(
+        isclose(
+            lhs.GetScalingFactor(),
+            rhs.GetScalingFactor(),
+            rel_tol=1e-10,
+            abs_tol=0.0,
+        ),
+        lhs.GetScalingFactor(),
+        rhs.GetScalingFactor(),
+        "ciphertexts have incompatible scales for addition.",
+        error_cls=ONPValueError,
+    )
+    return lhs, rhs
+
+
+# ------------------------------------------------------------------------------
+# Block flattening and cross-block carry evaluation
+# ------------------------------------------------------------------------------
+
+
+def _flatten_block_matrix_to_c_order_vector(
+    block_tensor: BlockCTArray,
+) -> BlockCTArray:
+    """Homomorphically repack a block matrix into a C-order block vector."""
+    block_size, frame_rows, chunks = _plan_block_matrix_flatten_moves(block_tensor)
+    ref_block = block_tensor.data[0]
+    blocks = []
+    total_cells = prod(block_tensor.original_shape)
+    cc = ref_block.crypto_context
+    fixed_manual = cc.GetScalingTechnique() == FIXEDMANUAL
+
+    for chunk_idx, chunk in enumerate(chunks):
+        data = None
+        for (block_idx, rotation), source_slots in chunk.items():
+            source = block_tensor.data[block_idx]
+            mask = cc.MakeCKKSPackedPlaintext(
+                _create_masking(source_slots, block_tensor.batch_size),
+                1,
+                source.data.GetLevel(),
+                None,
+                block_tensor.batch_size,
+            )
+            term = cc.EvalMult(source.data, mask)
+            if fixed_manual:
+                cc.ModReduceInPlace(term)
+            if rotation:
+                term = cc.EvalRotate(term, rotation)
+
+            if data is None:
+                data = term
+            else:
+                data, term = _prepare_ciphertexts_for_addition(
+                    cc,
+                    data,
+                    term,
+                )
+                data = cc.EvalAdd(data, term)
+
+        if data is None:
+            raise RuntimeError("internal cumsum error: flattened block is empty.")
+
+        start = chunk_idx * block_size
+        num_cells = min(block_size, total_cells - start)
+        blocks.append(
+            CTArray(
+                data=data,
+                original_shape=(num_cells,),
+                batch_size=block_tensor.batch_size,
+                new_shape=(frame_rows, 1),
+                order=block_tensor.order,
+                geometry=FramePacking(
+                    active=(num_cells, 1),
+                    padding="zero",
+                    repeats=1,
+                ),
+            )
+        )
+
+    return BlockCTArray(
+        data=blocks,
+        grid_shape=(len(blocks),),
+        block_shape=(block_size,),
+        original_shape=(prod(block_tensor.original_shape),),
+        batch_size=block_tensor.batch_size,
+        order=block_tensor.order,
+    )
+
+
+def _iter_block_chain_cumsum_with_carry(
+    block_tensor: BlockCTArray,
+    block_chain: tuple[int, ...],
+    axis: int,
+) -> Iterator[tuple[int, CTArray]]:
+    """Yield local cumsums while propagating carry through one block chain.
+
+    Notes
+    -----
+    The terminal value of each lane is moved to its origin and accumulated.
+    Before the next block is yielded, that carry is replicated across its active
+    lane and added to its local cumsum.
+    """
+    ref_block = block_tensor.data[block_chain[0]]
+    cc = ref_block.crypto_context
+    frame_rows, frame_cols = ref_block.shape
+    frame_size = frame_rows * frame_cols
+    repeats = ref_block.geometry.repeats
+    lane_size, num_lanes, slot_stride = _get_cumsum_lane_parameters(
+        ref_block,
+        axis,
+    )
+
+    last_idx = block_chain[-1]
+    needs_carry = len(block_chain) > 1
+    last_lane_size = lane_size
+    if needs_carry:
+        last_lane_size, _, _ = _get_cumsum_lane_parameters(
+            block_tensor.data[last_idx],
+            axis,
+        )
+
+    total_slots = []
+    if needs_carry:
+        last_pos = lane_size - 1
+        for frame_idx in range(repeats):
+            frame_offset = frame_idx * frame_size
+            for lane_idx in range(num_lanes):
+                if axis == 0:
+                    cell_row, cell_col = last_pos, lane_idx
+                else:
+                    cell_row, cell_col = lane_idx, last_pos
+                total_slots.append(
+                    frame_offset
+                    + _get_slot_index(
+                        cell_row,
+                        cell_col,
+                        ref_block.shape,
+                        ref_block.order,
+                    )
+                )
+
+    mask_values = _create_masking(total_slots, ref_block.batch_size) if total_slots else None
+    total_rotation = (lane_size - 1) * slot_stride
+    masks = {}
+    carry_total = None
+
+    for block_idx in block_chain:
+        block = block_tensor.data[block_idx]
+        local_cumsum = block.cumsum(axis=axis)
+        is_last = block_idx == last_idx
+
+        result = local_cumsum
+        if carry_total is not None:
+            current_lane_size = last_lane_size if is_last else lane_size
+            carry = _replicate_pattern(
+                carry_total,
+                copies=current_lane_size,
+                stride=slot_stride,
+            )
+            local_data, carry = _prepare_ciphertexts_for_addition(cc, local_cumsum.data, carry)
+            result = local_cumsum.clone(data=cc.EvalAdd(local_data, carry))
+
+        if not is_last:
+            level = local_cumsum.data.GetLevel()
+            if level not in masks:
+                masks[level] = cc.MakeCKKSPackedPlaintext(
+                    mask_values,
+                    1,
+                    level,
+                    None,
+                    ref_block.batch_size,
+                )
+            total = cc.EvalMult(
+                local_cumsum.data,
+                masks[level],
+            )
+            if cc.GetScalingTechnique() == FIXEDMANUAL:
+                cc.ModReduceInPlace(total)
+
+            if total_rotation:
+                total = cc.EvalRotate(total, total_rotation)
+            if carry_total is None:
+                carry_total = total
+            else:
+                carry_total, total = _prepare_ciphertexts_for_addition(cc, carry_total, total)
+                carry_total = cc.EvalAdd(carry_total, total)
+
+        yield block_idx, result
+
+
+# ------------------------------------------------------------------------------
+# BlockCTArray evaluation entry point
+# ------------------------------------------------------------------------------
+
+
+def _eval_block_cumsum(
+    block_tensor: BlockCTArray,
+    axis: int | None = None,
+) -> BlockCTArray:
+    """Evaluate one logical cumsum across an encrypted block tensor.
+
+    Parameters
+    ----------
+    block_tensor : BlockCTArray
+        Encrypted block vector or matrix with compatible child geometry.
+    axis : int or None, optional
+        NumPy-style axis. Vector ``None`` is equivalent to ``0``. Matrix
+        ``None`` first flattens values in logical C order and then scans the
+        resulting vector.
+
+    Returns
+    -------
+    BlockCTArray
+        Block tensor containing the complete logical cumsum. Matrix
+        ``axis=None`` returns a one-dimensional ``BlockCTArray``; axis-specific
+        matrix scans retain the input block layout. All result children are
+        advanced to one common ciphertext level.
+
+    Raises
+    ------
+    TypeError
+        If ``axis`` is neither ``None`` nor an integer.
+    ONPDimensionError
+        If ``axis`` is outside the tensor rank.
+    ONPValueError
+        If child geometry, packing layout, or ciphertext scales are
+        incompatible with the selected cumsum path.
+
+    Notes
+    -----
+    A row-major matrix with one block column and contiguous child frames uses a
+    metadata-only flattening fast path. Other matrix layouts use homomorphic
+    mask-and-rotate flattening. Axis-specific scans keep the original blocks and
+    propagate exact carry between consecutive children along each block chain.
+    """
+    axis, block_chains = _validate_and_plan_block_cumsum(block_tensor, axis)
+
+    if axis is None:
+        if _can_view_block_matrix_as_c_order_vector(block_tensor):
+            block_tensor = _view_block_matrix_as_c_order_vector(block_tensor)
+        else:
+            block_tensor = _flatten_block_matrix_to_c_order_vector(block_tensor)
+        axis, block_chains = _validate_and_plan_block_cumsum(block_tensor, axis=0)
+
+    results = [None] * block_tensor.num_blocks
+
+    for block_chain in block_chains:
+        for block_idx, result in _iter_block_chain_cumsum_with_carry(
+            block_tensor,
+            block_chain,
+            axis,
+        ):
+            results[block_idx] = result
+
+    if any(block is None for block in results):
+        raise RuntimeError("internal cumsum error: not every result block was produced.")
+
+    target_level = max(block.data.GetLevel() for block in results)
+    for block_idx, block in enumerate(results):
+        data = _advance_ciphertext_to_level(
+            block.crypto_context,
+            block.data,
+            target_level,
+        )
+        if data is not block.data:
+            results[block_idx] = block.clone(data=data)
+
+    return block_tensor.clone(data=results)

--- a/openfhe_numpy/operations/broadcast.py
+++ b/openfhe_numpy/operations/broadcast.py
@@ -38,6 +38,7 @@ import numpy as np
 from ..openfhe_numpy import ArrayEncodingType
 from ..tensor.constructors import _pack_block, array
 from ..tensor.ctarray import CTArray
+from ..tensor.tensor import FramePacking
 from ..utils._helper_slots_ops import (
     _create_masking,
     _replicate_pattern,
@@ -295,9 +296,7 @@ def _broadcast_rotation_indices(
     indices = set()
 
     def add_replication(copies, stride):
-        indices.update(
-            rotation for rotation, _ in _replication_steps(copies, stride)
-        )
+        indices.update(rotation for rotation, _ in _replication_steps(copies, stride))
 
     if len(logical_shape) == 1:
         _require(
@@ -331,23 +330,19 @@ def _broadcast_rotation_indices(
         add_replication(logical_shape[0], 1)
         return indices
 
-    source_shape, logical_shape, physical_shape = (
-        _validate_matrix_broadcast_geometry(
-            source_shape=source_shape,
-            logical_shape=logical_shape,
-            physical_shape=physical_shape,
-            order=order,
-            allow_order_union=True,
-        )
+    source_shape, logical_shape, physical_shape = _validate_matrix_broadcast_geometry(
+        source_shape=source_shape,
+        logical_shape=logical_shape,
+        physical_shape=physical_shape,
+        order=order,
+        allow_order_union=True,
     )
     source_kind = _slot_source_kind(source_shape)
 
     logical_rows, logical_cols = logical_shape
     physical_rows, physical_cols = physical_shape
     orders = (
-        (ArrayEncodingType.ROW_MAJOR, ArrayEncodingType.COL_MAJOR)
-        if order is None
-        else (order,)
+        (ArrayEncodingType.ROW_MAJOR, ArrayEncodingType.COL_MAJOR) if order is None else (order,)
     )
 
     for current_order in orders:
@@ -364,10 +359,7 @@ def _broadcast_rotation_indices(
             if current_order == ArrayEncodingType.ROW_MAJOR:
                 add_replication(logical_rows, physical_cols)
             else:
-                indices.update(
-                    -i * (physical_rows - 1)
-                    for i in range(1, source_cols)
-                )
+                indices.update(-i * (physical_rows - 1) for i in range(1, source_cols))
                 add_replication(logical_rows, 1)
 
         elif source_kind == "column":
@@ -375,10 +367,7 @@ def _broadcast_rotation_indices(
             if current_order == ArrayEncodingType.COL_MAJOR:
                 add_replication(logical_cols, physical_rows)
             else:
-                indices.update(
-                    -i * (physical_cols - 1)
-                    for i in range(1, source_rows)
-                )
+                indices.update(-i * (physical_cols - 1) for i in range(1, source_rows))
                 add_replication(logical_cols, 1)
 
     indices.discard(0)
@@ -527,6 +516,11 @@ def _broadcast_to_vector(x, logical_shape, order=None, cc=None):
             batch_size=x.batch_size,
             new_shape=physical_shape,
             order=resolved_order,
+            geometry=FramePacking(
+                active=(logical_length, 1),
+                padding="zero",
+                repeats=1,
+            ),
         )
 
     if x.dtype == "PTArray":
@@ -596,14 +590,12 @@ def _broadcast_to_physical_slots(
     ONPValueError
         If the order, batch capacity, or plaintext context is invalid.
     """
-    source_shape, logical_shape, physical_shape = (
-        _validate_matrix_broadcast_geometry(
-            source_shape=x.original_shape,
-            logical_shape=logical_shape,
-            physical_shape=physical_shape,
-            order=order,
-            allow_order_union=False,
-        )
+    source_shape, logical_shape, physical_shape = _validate_matrix_broadcast_geometry(
+        source_shape=x.original_shape,
+        logical_shape=logical_shape,
+        physical_shape=physical_shape,
+        order=order,
+        allow_order_union=False,
     )
 
     _require(
@@ -615,11 +607,7 @@ def _broadcast_to_physical_slots(
     )
 
     # Packed identity requires logical, physical, and order equality.
-    if (
-        source_shape == logical_shape
-        and tuple(x.shape) == physical_shape
-        and x.order == order
-    ):
+    if source_shape == logical_shape and tuple(x.shape) == physical_shape and x.order == order:
         return x
 
     source_kind = _slot_source_kind(source_shape)
@@ -746,6 +734,11 @@ def _ct_broadcast_to(x, logical_shape, physical_shape, order, source_kind):
         batch_size=x.batch_size,
         new_shape=physical_shape,
         order=order,
+        geometry=FramePacking(
+            active=logical_shape,
+            padding="zero",
+            repeats=1,
+        ),
     )
 
 

--- a/openfhe_numpy/operations/matrix_api.py
+++ b/openfhe_numpy/operations/matrix_api.py
@@ -257,19 +257,19 @@ def transpose(a: ArrayLike) -> ArrayLike:
 
 
 @tensor_function_api("cumsum", binary=False)
-def cumsum(a: ArrayLike, /, *, axis: Optional[int] = None) -> ArrayLike:
-    """
-        Compute the cumulative sum of tensor elements along a specified axis.\
-        - For 1D inputs, axis must be None.
-        - For 2D inputs, axis must be 0 or 1.
-        - The include_initial argument is not supported.
+def cumsum(a: ArrayLike, axis: Optional[int] = None) -> ArrayLike:
+    """Compute cumulative sums using NumPy axis behavior.
 
-        Parameters
-        ----------
-        a : ArrayLike
-            Input tensor.
-        axis : int, optional
-            Axis along which to compute the sum. Default is 0.
+    For vectors, ``None``, ``0``, and ``-1`` scan the vector. For matrices,
+    ``None`` scans the C-order flattened values and returns a vector, while
+    ``0`` and ``1`` scan down rows and across columns respectively.
+
+    Parameters
+    ----------
+    a : ArrayLike
+        Input tensor.
+    axis : int, optional
+        Axis along which to compute the sum. Default is ``None``.
 
     Returns
     -------
@@ -279,6 +279,12 @@ def cumsum(a: ArrayLike, /, *, axis: Optional[int] = None) -> ArrayLike:
     See Also
     --------
     numpy.cumsum : Corresponding NumPy function.
+
+    Notes
+    -----
+    For a block matrix with ``axis=None``, the current implementation assembles
+    logical values in C order one element at a time. It can be
+    expensive for large matrices.
 
     Examples
     --------

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -62,6 +62,7 @@ from openfhe_numpy.openfhe_numpy import (
 from openfhe_numpy.operations.arithmetic_utils import (
     _eval_binary,
     _eval_scalar_binary,
+    _normalize_axis,
 )
 
 
@@ -288,12 +289,16 @@ def pow_ct(a, exp):
 
 @register_tensor_function(
     "cumsum",
-    [("CTArray",), ("CTArray", "int"), ("CTArray", "int", "bool")],
+    [
+        ("CTArray",),
+        ("CTArray", "NoneType"),
+        ("CTArray", "int"),
+        ("CTArray", "scalar"),
+    ],
 )
-def cumsum_ct(obj, axis=0, keepdims=True):
+def cumsum_ct(obj, axis=None):
     """Compute cumulative sum of a tensor along specified axis."""
-    # return _cumsum_ct(a, axis, keepdims)
-    return obj.cumsum(axis)
+    return obj.cumsum(axis=axis)
 
 
 # ------------------------------------------------------------------------------
@@ -330,6 +335,7 @@ def _reduce_ct(a, axis=0, keepdims=False):
 @register_tensor_function("cumulative_reduce", [("CTArray", "int", "bool")])
 def cumulative_reduce_ct(a, axis=0, keepdims=False):
     """Compute cumulative reduction of a tensor along specified axis."""
+    axis = _normalize_axis("cumulative_reduce", axis, a.ndim)
     return _reduce_ct(a, axis, keepdims)
 
 
@@ -438,7 +444,7 @@ def _ct_sum_vector(
     axis: Optional[int] = None,
 ):
     crypto_context = x.data.GetCryptoContext()
-    if axis is not None:
+    if axis not in (None, 0):
         raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
     ct_sum = crypto_context.EvalSum(x.data, x.shape[0])
     return CTArray(ct_sum, (), x.batch_size, x.shape, x.order)
@@ -446,12 +452,13 @@ def _ct_sum_vector(
 
 @register_tensor_function("sum", [("CTArray",), ("CTArray", "int"), ("CTArray", "int", "bool")])
 def sum_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
+    if x.ndim not in (1, 2):
+        raise ONPDimensionError(f"sum requires a vector or matrix; got {x.ndim}D.")
+
+    axis = _normalize_axis("sum", axis, x.ndim)
     if x.ndim == 2:
         return _ct_sum_matrix(x, axis, keepdims)
-    elif x.ndim == 1:
-        return _ct_sum_vector(x, axis)
-    else:
-        raise ONPDimensionError(f"The dimension is invalid = {x.ndims}")
+    return _ct_sum_vector(x, axis)
 
 
 # ------------------------------------------------------------------------------
@@ -461,17 +468,25 @@ def sum_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
 
 @register_tensor_function("mean", [("CTArray",), ("CTArray", "int"), ("CTArray", "int", "bool")])
 def mean_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
+    if x.ndim not in (1, 2):
+        raise ONPDimensionError(f"mean requires a vector or matrix; got {x.ndim}D.")
+
+    axis = _normalize_axis("mean", axis, x.ndim)
     cc = x.data.GetCryptoContext()
-    nrows, ncols = x.original_shape
     sum_x = sum_ct(x, axis, keepdims)
-    if axis is None:
-        ct_mean = cc.EvalMult(sum_x.data, 1.0 / (nrows * ncols))
-    elif axis == 0:  # sum over rows
-        ct_mean = cc.EvalMult(sum_x.data, 1.0 / nrows)
-    elif axis == 1:  # sum over cols
-        ct_mean = cc.EvalMult(sum_x.data, 1.0 / ncols)
+
+    if x.ndim == 1:
+        count = x.original_shape[0]
     else:
-        raise ONPDimensionError(f"The dimension is invalid axis = {axis}")
+        nrows, ncols = x.original_shape
+        if axis is None:
+            count = nrows * ncols
+        elif axis == 0:
+            count = nrows
+        else:
+            count = ncols
+
+    ct_mean = cc.EvalMult(sum_x.data, 1.0 / count)
 
     return CTArray(
         ct_mean,
@@ -487,12 +502,24 @@ def mean_ct(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = False):
 # ------------------------------------------------------------------------------
 
 
-@register_tensor_function("roll", [("CTArray", "int"), ("CTArray", "int", "int")])
+@register_tensor_function(
+    "roll",
+    [
+        ("CTArray", "int"),
+        ("CTArray", "int", "int"),
+        ("CTArray", "scalar", "scalar"),
+    ],
+)
 def roll(x: ArrayLike, shift: int, axis: Optional[int] = None) -> ArrayLike:
-    if axis is None:
-        return _ct_vector_rotation(x, -shift)
-    else:
-        raise ONPError(f"This function only supports packed vector")
+    if x.ndim != 1:
+        raise ONPNotSupportedError("roll currently supports only packed vectors.")
+
+    axis = _normalize_axis("roll", axis, x.ndim)
+    if axis is not None:
+        raise ONPNotSupportedError(
+            "roll currently supports only packed vectors with axis=None."
+        )
+    return _ct_vector_rotation(x, -shift)
 
 
 def _ct_vector_rotation(ctv: CTArray, shift: int):

--- a/openfhe_numpy/tensor/block_tensor.py
+++ b/openfhe_numpy/tensor/block_tensor.py
@@ -561,9 +561,9 @@ class BlockFHETensor(BaseTensor, Generic[TPL]):
         """Sum block tensor entries through tensor dispatch."""
         return self.__tensor_function__("sum", (self,), {"axis": axis, "keepdims": keepdims})
 
-    def cumsum(self, axis=None, keepdims: bool = False):
+    def cumsum(self, axis=None):
         """Compute cumulative sums through tensor dispatch."""
-        return self.__tensor_function__("cumsum", (self,), {"axis": axis, "keepdims": keepdims})
+        return self.__tensor_function__("cumsum", (self,), {"axis": axis})
 
     def transpose(self):
         """Transpose the block tensor through tensor dispatch.

--- a/openfhe_numpy/tensor/constructors.py
+++ b/openfhe_numpy/tensor/constructors.py
@@ -47,7 +47,7 @@ from openfhe import CryptoContext, PublicKey
 # Package-level imports
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
 from openfhe_numpy.utils.errors import ONPError
-from openfhe_numpy.utils.matlib import is_power_of_two
+from openfhe_numpy.utils.matlib import is_power_of_two, next_power_of_two
 from openfhe_numpy.utils.packing import (
     _pack_matrix_col_wise,
     _pack_matrix_row_wise,
@@ -62,7 +62,7 @@ from openfhe_numpy.utils.typecheck import (
 
 
 # Tensor imports
-from .tensor import FHETensor, PackedArrayInformation
+from .tensor import FHETensor, PackedArrayInformation, FramePacking
 from .ctarray import CTArray
 from .ptarray import PTArray
 from .block_tensor import BlockFHETensor
@@ -84,25 +84,15 @@ def _compute_block_dimensions(
     shape: tuple[int, ...],
     batch_size: int,
     block_shape: tuple[int, ...] | None = None,
-    order: int = ArrayEncodingType.ROW_MAJOR,
     target_cols: int | None = None,
-    compact: bool = False,
 ) -> tuple[int, ...]:
-    """Choose block dimensions if block_shape is None.
+    """Compute block dimensions or choose the largest size by default.
     Default rules:
-        Vector  (n,)    -> (batch_size,), or (side,) where
-                           side = 2^floor(log2(batch_size)/2) if compact=True
-        Column  (m, 1)  -> (batch_size, 1)
-        Row     (1, n)  -> (1, batch_size)
-        General (m, n)  -> (side, side) where side = 2^floor(log2(batch_size)/2)
-    ``compact=True`` requests the smaller, square-compatible vector block
-    size required to pair a block vector with a block matrix for block
-    matrix-vector multiplication (see ``block_array``'s ``compact``
-    parameter). Plain block vectors used for vector-vector arithmetic
-    (add/sub/multiply/dot/matmul) should use the default, non-compact sizing.
-    TODO:
-    [OPTIONAL] For rectangular matrices where one dimension fits in a single
-    block, use rectangular block_shape to reduce wasted slots.
+    Vector  (n,)    -> (batch_size,), or (side,) where
+                       side = 2^floor(log2(batch_size)/2) if compact=True
+    Column  (m, 1)  -> (batch_size, 1)
+    Row     (1, n)  -> (1, batch_size)
+    General (m, n)  -> (side, side) where side = 2^floor(log2(batch_size)/2)
     """
     if len(shape) not in (1, 2):
         raise ValueError(f"Only 1-D or 2-D shapes are supported; got {shape}.")
@@ -110,6 +100,17 @@ def _compute_block_dimensions(
         raise ValueError(f"batch_size must be positive; got {batch_size}.")
     if any(dim <= 0 for dim in shape):
         raise ValueError(f"shape must be positive; got {shape}.")
+
+    physical_cols = 1
+    if target_cols is not None:
+        if len(shape) != 1:
+            raise ValueError("target_cols is only valid for block vectors.")
+        if not isinstance(target_cols, int) or target_cols <= 0:
+            raise ValueError(f"target_cols must be a positive integer, got {target_cols!r}.")
+        physical_cols = next_power_of_two(target_cols)
+        if physical_cols > batch_size:
+            raise ValueError(f"target_cols={target_cols} exceeds batch_size={batch_size}.")
+
     if block_shape is not None:
         block_shape = tuple(block_shape)
         if len(block_shape) != len(shape):
@@ -119,9 +120,14 @@ def _compute_block_dimensions(
             )
         if any(dim <= 0 for dim in block_shape):
             raise ValueError(f"block_shape must be positive; got {block_shape}.")
-        if prod(block_shape) > batch_size:
+
+        required_slots = prod(block_shape)
+        if len(shape) == 1:
+            required_slots = next_power_of_two(block_shape[0]) * physical_cols
+
+        if required_slots > batch_size:
             raise ValueError(
-                f"block_shape={block_shape} uses {prod(block_shape)} slots, "
+                f"block_shape={block_shape} uses {required_slots} slots, "
                 f"but batch_size={batch_size}."
             )
         if len(block_shape) == 2:
@@ -131,19 +137,10 @@ def _compute_block_dimensions(
                     f"Matrix block dimensions must be powers of two; got block_shape={block_shape}."
                 )
         return block_shape
-    if target_cols is not None:
-        if len(shape) != 1:
-            raise ValueError("target_cols is only valid for block vectors.")
-        if not isinstance(target_cols, int) or target_cols <= 0:
-            raise ValueError(f"target_cols must be a positive integer, got {target_cols!r}.")
-        if target_cols > batch_size:
-            raise ValueError(f"target_cols={target_cols} exceeds batch_size={batch_size}.")
-        return (target_cols,)
+
     if len(shape) == 1:
-        if not compact:
-            return (batch_size,)
-        side = 1 << ((batch_size.bit_length() - 1) // 2)
-        return (side,)
+        return (batch_size // physical_cols,)
+
     m, n = shape
     if n == 1:
         return (batch_size, 1)
@@ -176,7 +173,16 @@ def _pack_block(
 ) -> PackedArrayInformation:
     """Pack a padded block while preserving its logical shape."""
     package = _pack_array(data, batch_size, order, mode, **kwargs)
+    original_shape = tuple(original_shape)
+    ndim = len(original_shape)
+    active = (original_shape[0], package.geometry.active[1]) if ndim == 1 else original_shape
     package.original_shape = original_shape
+    package.ndim = ndim
+    package.geometry = FramePacking(
+        active=active,
+        padding=package.geometry.padding,
+        repeats=package.geometry.repeats,
+    )
     return package
 
 
@@ -186,70 +192,47 @@ def block_array(
     block_shape: tuple | None = None,
     batch_size: int | None = None,
     order: int = ArrayEncodingType.ROW_MAJOR,
-    mode: str = "tile",
+    mode: str = "zero",
     fhe_type: Literal["C", "P"] = "C",
     public_key=None,
     target_cols: int | None = None,
-    compact: bool = False,
+    expand: Literal["tile", "zero"] = "tile",
+    pad_value: Literal["tile", "zero"] = "zero",
 ) -> BlockFHETensor:
     """Construct a block-encoded plaintext or ciphertext tensor.
 
-    ``block_shape`` determines the partition. A vector is divided into blocks of
-    ``b`` elements; a matrix is divided into ``br x bc`` tiles. Thus,
+    The input is divided into blocks of ``block_shape``. Boundary blocks are
+    zero-padded, and each block is packed into one CKKS plaintext or ciphertext.
+    When ``block_shape`` is omitted, a suitable shape is selected from
+    ``batch_size``.
 
-    - vector: ``grid_shape = (ceil(n / b),)``;
-    - matrix: ``grid_shape = (ceil(m / br), ceil(n / bc))``.
-
-    Matrix block ``(i, j)`` contains
-    ``data[i*br:(i+1)*br, j*bc:(j+1)*bc]``. Boundary blocks are zero-padded to
-    ``block_shape`` and stored in row-major grid order.
-
-    If ``block_shape`` is omitted, let ``B = batch_size`` and let ``s`` be the
-    largest power of two satisfying ``s**2 <= B``. The defaults are
-
-    - ``(B,)`` for a vector;
-    - ``(s,)`` for a compact vector;
-    - ``(B, 1)`` for a column matrix;
-    - ``(1, B)`` for a row matrix;
-    - ``(s, s)`` for a general matrix.
-
-    Each block is packed into one CKKS plaintext or ciphertext. ``order`` controls
-    the slot order within a block, while ``mode`` controls whether unused slots are
-    tiled or zero-filled.
-
-    For vectors, ``compact=True`` expands each length-``b`` block into the
-    ``b x b`` layout required by block matrix-vector multiplication, with
-    ``b**2 <= batch_size``. Compatible packing orders are
-
-    - ``ROW_MAJOR`` matrix with ``COL_MAJOR`` vector;
-    - ``COL_MAJOR`` matrix with ``ROW_MAJOR`` vector.
-
-    Compact packing replicates vector entries and is unsuitable for ordinary
-    vector arithmetic, dot products, or vector-vector matrix multiplication.
-    Providing ``target_cols`` also enables compact packing.
+    For vectors, ``target_cols`` creates a matrix-compatible frame. ``expand``
+    controls value replication, while ``pad_value`` controls padded columns.
 
     Parameters
     ----------
-    cc
+    cc : CryptoContext
         OpenFHE crypto context.
-    data
-        Nonempty one- or two-dimensional input.
-    block_shape
-        Shape of each logical block.
-    batch_size
+    data : array-like
+        Nonempty vector or matrix.
+    block_shape : tuple, optional
+        Block dimensions. Selected automatically when omitted.
+    batch_size : int, optional
         CKKS slots per block. Defaults to ``cc.GetBatchSize()``.
-    order
-        Encoding order within each block.
-    mode
-        Unused-slot filling mode: ``"tile"`` or ``"zero"``.
-    fhe_type
-        ``"C"`` for ciphertext or ``"P"`` for plaintext.
-    public_key
+    order : ArrayEncodingType
+        Slot order within each block.
+    mode : {"tile", "zero"}
+        Repeat each block frame or zero-fill unused slots.
+    fhe_type : {"C", "P"}
+        Ciphertext or plaintext output.
+    public_key : PublicKey, optional
         Required when ``fhe_type="C"``.
-    target_cols
-        Compact vector block length when ``block_shape`` is omitted.
-    compact
-        Enable matrix-vector-compatible vector packing.
+    target_cols : int, optional
+        Active columns in an expanded vector block.
+    expand : {"tile", "zero"}
+        Repeat vector values across columns or use only the first column.
+    pad_value : {"tile", "zero"}
+        Repeat values into padded columns or leave them zero.
 
     Returns
     -------
@@ -272,14 +255,17 @@ def block_array(
         raise ValueError("Scalar input not supported. Use array() instead.")
     if arr.ndim > 2:
         raise ValueError(f"Only 1-D and 2-D supported; got shape {arr.shape}.")
-    is_compact = compact or target_cols is not None
+    if expand not in ("tile", "zero"):
+        raise ValueError("expand must be 'tile' or 'zero'.")
+    if pad_value not in ("tile", "zero"):
+        raise ValueError("pad_value must be 'tile' or 'zero'.")
+    if arr.ndim != 1 and (expand != "tile" or pad_value != "zero"):
+        raise ValueError("expand and pad_value are valid only for block vectors.")
     block_shape = _compute_block_dimensions(
         original_shape,
         batch_size,
         block_shape,
-        order=order,
         target_cols=target_cols,
-        compact=is_compact,
     )
     grid_shape = _compute_grid_shape(original_shape, block_shape)
     block_cls = BlockCTArray if fhe_type == "C" else BlockPTArray
@@ -291,15 +277,15 @@ def block_array(
             stop = min(start + chunk, original_shape[0])
             tile = np.zeros(block_shape, dtype=arr.dtype)
             tile[: stop - start] = arr[start:stop]
-            # Compact packing repeats vector entries for matrix-vector multiplication.
-            vector_target_cols = chunk if is_compact and chunk * chunk <= batch_size else None
             package = _pack_block(
                 tile,
                 (stop - start,),
                 batch_size,
                 order,
                 mode,
-                target_cols=vector_target_cols,
+                target_cols=target_cols,
+                expand=expand,
+                pad_value=pad_value,
             )
             blocks.append(
                 array(
@@ -382,33 +368,67 @@ def _pack_array(
       - shape          : tuple (rows, cols)
       - order          : int
     """
-    if batch_size < 0:
-        raise ONPError("The batch size cannot be negative.")
+    if batch_size <= 0:
+        raise ONPError("The batch size must be positive.")
     if not is_power_of_two(batch_size):
         raise ONPError(f"Batch size [{batch_size}] must be a power of two.")
+    if mode not in ("zero", "tile"):
+        raise ONPError(f"Invalid padding mode: {mode!r}.")
 
     data = np.asarray(data)
 
     if is_numeric_scalar(data):
+        if kwargs:
+            raise ONPError("target_cols, expand, and pad_value are valid only for vectors.")
+
         if mode == "zero":
             packed = np.zeros(batch_size, dtype=data.dtype)
             packed[0] = data
-        elif mode == "tile":
-            packed = np.full(batch_size, data)
         else:
-            raise ONPError(f"Invalid padding mode: '{mode}'. Use 'zero' or 'tile'.")
-        shape = (batch_size, 1)
+            packed = np.full(batch_size, data)
+
+        shape = (1, 1)
+        active = (1, 1)
+        padding = "zero"
+
+    elif is_numeric_arraylike(data) and data.ndim == 1:
+        target_cols = kwargs.get("target_cols")
+        expand = kwargs.get("expand", "tile")
+        pad_value = kwargs.get("pad_value", "tile")
+
+        if expand not in ("tile", "zero"):
+            raise ONPError("expand must be 'tile' or 'zero'.")
+        if pad_value not in ("tile", "zero"):
+            raise ONPError("pad_value must be 'tile' or 'zero'.")
+
+        packed, shape = _ravel_vector(data, batch_size, order, True, mode, **kwargs)
+
+        if target_cols is None:
+            active = (len(data), 1)
+            padding = "zero"
+        elif expand == "tile":
+            active = (len(data), target_cols)
+            padding = pad_value if target_cols < shape[1] else "zero"
+        else:
+            active = (len(data), 1)
+            padding = "zero"
+
+    elif is_numeric_arraylike(data) and data.ndim == 2:
+        if kwargs:
+            raise ONPError("target_cols, expand, and pad_value are valid only for vectors.")
+
+        packed, shape = _ravel_matrix(data, batch_size, order, True, mode)
+        active = tuple(data.shape)
+        padding = "zero"
 
     elif is_numeric_arraylike(data):
-        if data.ndim == 2:
-            packed, shape = _ravel_matrix(data, batch_size, order, True, mode, **kwargs)
-        elif data.ndim == 1:
-            packed, shape = _ravel_vector(data, batch_size, order, True, mode, **kwargs)
-        else:
-            raise ONPError(f"Unsupported data dimension [{data.ndim}].")
+        raise ONPError(f"Unsupported data dimension [{data.ndim}].")
 
     else:
         raise ONPError("Input is not numeric.")
+
+    frame_size = shape[0] * shape[1]
+    repeats = 1 if mode == "zero" else batch_size // frame_size
 
     return PackedArrayInformation(
         data=packed,
@@ -417,6 +437,11 @@ def _pack_array(
         batch_size=batch_size,
         shape=shape,
         order=order,
+        geometry=FramePacking(
+            active=active,
+            padding=padding,
+            repeats=repeats,
+        ),
     )
 
 
@@ -436,25 +461,70 @@ def array(
 
     Parameters
     ----------
-    cc         : CryptoContext
-    data       : matrix | vector | scalar
-    batch_size : Optional[int]
-    order      : ArrayEncodingType
-    fhe_type   : "C" (ciphertext) or "P" (plaintext)
-    package    : dict from `_pack_array` (optional)
-    public_key : required if type == "C"
+    cc : CryptoContext
+        OpenFHE crypto context.
+    data : array-like
+        Scalar, vector, or matrix to pack.
+    batch_size : int, optional
+        Number of CKKS slots. Defaults to ``cc.GetBatchSize()``.
+    order : ArrayEncodingType
+        ``ROW_MAJOR`` or ``COL_MAJOR``. Default is ``ROW_MAJOR``.
+    fhe_type : {"C", "P"}
+        Ciphertext or plaintext output. Default is ``"P"``.
+    mode : {"tile", "zero"}, optional
+        Repeat the packed frame or zero-fill unused slots. Default is ``"tile"``.
+    package : PackedArrayInformation, optional
+        Prepacked data used internally by ``block_array``.
+    public_key : PublicKey, optional
+        Required for ``fhe_type="C"``.
+    **kwargs
+        Vector packing options: ``target_cols``, ``expand``, and ``pad_value``.
 
     Returns
     -------
     FHETensor
+        ``CTArray`` for ``"C"`` or ``PTArray`` for ``"P"``.
+
+    Examples
+    --------
+    Use the matrix and logical column vector::
+
+        matrix = [[1, 2, 3],
+                  [4, 5, 6],
+                  [7, 8, 9]]
+        vector = [1, 2, 3]
+
+    Their dimensions pad from 3 to 4. With one frame and zero tail::
+
+        >>> array(cc, matrix, batch_size=32, order=ROW_MAJOR, mode="zero")
+        # 1 2 3 0 | 4 5 6 0 | 7 8 9 0 | 0 0 0 0 | then 16 zeros
+
+        >>> array(cc, matrix, batch_size=32, order=COL_MAJOR, mode="zero")
+        # 1 4 7 0 | 2 5 8 0 | 3 6 9 0 | 0 0 0 0 | then 16 zeros
+
+        >>> array(cc, vector, batch_size=32, mode="zero")
+        # 1 2 3 0 | then 28 zeros
+
+    ``target_cols=3`` creates a ``4 x 4`` physical vector frame::
+
+        >>> array(cc, vector, batch_size=32, target_cols=3, mode="zero")
+        # 1 1 1 1 | 2 2 2 2 | 3 3 3 3 | 0 0 0 0 | then 16 zeros
+
+        >>> array(cc, vector, batch_size=32, target_cols=3,
+        ...       pad_value="zero", mode="zero")
+        # 1 1 1 0 | 2 2 2 0 | 3 3 3 0 | 0 0 0 0 | then 16 zeros
+
+        >>> array(cc, vector, batch_size=32, target_cols=3,
+        ...       expand="zero", mode="zero")
+        # 1 0 0 0 | 2 0 0 0 | 3 0 0 0 | 0 0 0 0 | then 16 zeros
+
+    ``mode="tile"`` repeats the padded frame to fill all slots.
     """
     if cc is None:
         raise ONPError("CryptoContext does not exist")
 
     if batch_size is None:
         batch_size = cc.GetBatchSize()
-    if not isinstance(batch_size, int) or batch_size < 0:
-        raise ONPError(f"batch_size must be a non-negative int or None, got {batch_size}.")
 
     if package is None:
         package = _pack_array(data, batch_size, order, mode, **kwargs)
@@ -471,6 +541,7 @@ def array(
             package.batch_size,  # batch_size
             package.shape,  # new_shape
             package.order,  # order
+            geometry=package.geometry,
         )
     elif fhe_type == "C":
         if public_key is None:
@@ -483,6 +554,7 @@ def array(
                 package.batch_size,  # batch_size
                 package.shape,  # new_shape
                 package.order,  # order
+                geometry=package.geometry,
             )
         except Exception as e:
             raise ONPError(f"Failed to encrypt: {e}")

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -29,20 +29,19 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ==================================================================================
 
-import io
 from typing import Optional, Tuple, Union, Callable, Any
 import numpy as np
 import openfhe
 
 
-from ..openfhe_numpy import EvalSumCumCols, EvalSumCumRows, EvalTranspose, ArrayEncodingType
-from ..utils.matlib import next_power_of_two
+from ..openfhe_numpy import EvalCumSum, EvalTranspose, ArrayEncodingType
+from ..utils.matlib import is_power_of_two, next_power_of_two
 from ..utils.constants import UnpackType
-from ..utils.errors import ONPError
+from ..utils.errors import ONPDimensionError, ONPError
 from ..utils.packing import process_packed_data
-from ..utils._helper_slots_ops import _get_single_element
+from ..utils._helper_slots_ops import _get_single_element, _get_slot_index
 
-from .tensor import FHETensor
+from .tensor import FHETensor, FramePacking
 
 
 class CTArray(FHETensor[openfhe.Ciphertext]):
@@ -140,26 +139,31 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             data=ct,
             original_shape=(),
             batch_size=self.batch_size,
-            new_shape=(),
+            new_shape=(1, 1),
             order=self.order,
+            geometry=FramePacking(
+                active=(1, 1),
+                padding="zero",
+                repeats=1,
+            ),
         )
 
-    def _cta_from_1d(self, cts):
-        """Combine a list of single ciphertexts into one 1D CTArray"""
+    def _cta_from_1d(self, cts, *, frame_rows=None):
+        """Combine single-slot ciphertexts into one packed 1-D CTArray."""
         cc = self.crypto_context
         N = len(cts)
-        NN = next_power_of_two(N)
+
+        if N == 0:
+            raise ONPError("Cannot assemble an empty encrypted vector.")
+
+        NN = next_power_of_two(N) if frame_rows is None else frame_rows
+
+        if not is_power_of_two(NN) or N > NN:
+            raise ONPError(f"N={N} does not fit frame_rows={NN}.")
+        if NN > self.batch_size:
+            raise ONPError(f"frame_rows={NN} exceeds batch_size={self.batch_size}.")
 
         ct_res = cts[0]
-        if N == 1:
-            return CTArray(
-                data=ct_res,
-                original_shape=(N,),
-                batch_size=self.batch_size,
-                new_shape=(NN,),
-                order=self.order,
-            )
-
         for i in range(1, N):
             ct_res = cc.EvalAdd(ct_res, cc.EvalRotate(cts[i], -i))
 
@@ -167,8 +171,13 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             data=ct_res,
             original_shape=(N,),
             batch_size=self.batch_size,
-            new_shape=(NN,),
+            new_shape=(NN, 1),
             order=self.order,
+            geometry=FramePacking(
+                active=(N, 1),
+                padding="zero",
+                repeats=1,
+            ),
         )
 
     def _cta_from_2d(self, matrix):
@@ -199,6 +208,11 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             batch_size=self.batch_size,
             new_shape=(power_2_r, power_2_c),
             order=self.order,
+            geometry=FramePacking(
+                active=(nrow, ncol),
+                padding="zero",
+                repeats=1,
+            ),
         )
 
     def _get_element_1D(self, key):
@@ -209,12 +223,7 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
         return _get_single_element(self.crypto_context, self.data, key, self.batch_size)
 
     def _get_element_2D(self, r, c):
-        if self.order == ArrayEncodingType.ROW_MAJOR:
-            idx = r * self.shape[1] + c
-        elif self.order == ArrayEncodingType.COL_MAJOR:
-            idx = c * self.shape[0] + r
-        else:
-            raise TypeError(f"Unsupported packing type: {self.order}")
+        idx = _get_slot_index(r, c, self.shape, self.order)
         return _get_single_element(self.crypto_context, self.data, idx, self.batch_size)
 
     def decrypt(
@@ -264,52 +273,6 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
 
         return result
 
-    def serialize(self) -> dict:
-        """
-        Serialize ciphertext and metadata to a dictionary.
-        """
-        stream = io.BytesIO()
-        if not openfhe.Serialize(self.data, stream):
-            raise ONPError("Failed to serialize ciphertext.")
-
-        return {
-            "type": self.type,
-            "original_shape": self.original_shape,
-            "batch_size": self.batch_size,
-            "ncols": self.ncols,
-            "order": self.order,
-            "ciphertext": stream.getvalue().hex(),
-        }
-
-    @classmethod
-    def deserialize(cls, obj: dict) -> "CTArray":
-        """
-        Deserialize a dictionary back into a CTArray.
-        """
-        required_keys = [
-            "ciphertext",
-            "original_shape",
-            "batch_size",
-            "ncols",
-            "order",
-        ]
-        for key in required_keys:
-            if key not in obj:
-                raise ONPError(f"Missing required key '{key}' in serialized object.")
-
-        stream = io.BytesIO(bytes.fromhex(obj["ciphertext"]))
-        ciphertext = openfhe.Ciphertext()
-        if not openfhe.Deserialize(ciphertext, stream):
-            raise ONPError("Failed to deserialize ciphertext.")
-
-        return cls(
-            ciphertext,
-            tuple(obj["original_shape"]),
-            obj["batch_size"],
-            obj["ncols"],
-            obj["order"],
-        )
-
     def __neg__(self) -> "CTArray":
         """Return the homomorphic negation of this ciphertext array."""
         cc = self.data.GetCryptoContext()
@@ -324,6 +287,15 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
                 self.original_shape[0],
             )
             padded_shape = (self.shape[1], self.shape[0])
+            geometry = (
+                None
+                if self.geometry is None
+                else FramePacking(
+                    active=(self.geometry.active[1], self.geometry.active[0]),
+                    padding=self.geometry.padding,
+                    repeats=self.geometry.repeats,
+                )
+            )
         elif self.ndim == 1:
             return self
         else:
@@ -334,16 +306,17 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             self.batch_size,
             padded_shape,
             self.order,
+            geometry=geometry,
         )
 
-    def cumsum(self, axis: int = 0) -> "CTArray":
-        """
-        Compute the cumulative sum of tensor elements along a given axis.
+    def cumsum(self, axis=None) -> "CTArray":
+        """Compute cumulative sums using the logical tensor geometry.
 
         Parameters
         ----------
         axis : int, optional
-            Axis along which the cumulative sum is computed. Default is 0.
+            Axis along which the cumulative sum is computed. ``None`` scans a
+            vector directly and flattens a matrix in logical C order.
 
         Returns
         -------
@@ -351,46 +324,92 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             A new tensor with cumulative sums along the specified axis.
         """
 
-        if self.ndim != 1 and self.ndim != 2:
-            raise ONPError(f"Dimension of array {self.ndim} is illegal ")
+        from ..operations.arithmetic_utils import _normalize_axis
 
-        if self.ndim != 1 and axis is None:
-            raise ONPError("axis=None not allowed for >1D")
+        from ..operations.block_cumsum import (
+            _can_flatten_ctarray_without_slot_moves,
+            _get_cumsum_lane_parameters,
+        )
 
-        if self.ndim == 2 and axis not in (0, 1):
-            raise ONPError("Axis must be 0 or 1 for cumulative sum operation")
+        if self.geometry is None:
+            raise ONPError("cumsum requires packed geometry; construct the tensor with array().")
 
-        order = self.order
-        shape = self.shape
-        original_shape = self.original_shape
+        if self.ndim not in (0, 1, 2):
+            raise ONPDimensionError(
+                f"cumsum requires a scalar, vector, or matrix; got {self.ndim}D."
+            )
 
-        if axis is None:
-            ciphertext = EvalSumCumRows(self.data, self.ncols, self.original_shape[1])
+        axis_ndim = 1 if self.ndim <= 1 else self.ndim
+        normalized_axis = _normalize_axis(
+            "cumsum",
+            axis,
+            axis_ndim,
+        )
+        if self.ndim <= 1 and normalized_axis is None:
+            normalized_axis = 0
 
-        # cumsum over rows
-        elif axis == 0:
-            if self.order == ArrayEncodingType.ROW_MAJOR:
-                ciphertext = EvalSumCumRows(self.data, self.ncols, self.original_shape[1])
+        if self.ndim == 2 and normalized_axis is None:
+            if _can_flatten_ctarray_without_slot_moves(self):
+                logical_size = self.original_shape[0] * self.original_shape[1]
+                frame_rows, frame_cols = self.shape
+                flattened = CTArray(
+                    data=self.data,
+                    original_shape=(logical_size,),
+                    batch_size=self.batch_size,
+                    new_shape=(frame_rows * frame_cols, 1),
+                    order=self.order,
+                    geometry=FramePacking(
+                        active=(logical_size, 1),
+                        padding="zero",
+                        repeats=self.geometry.repeats,
+                    ),
+                )
+                return flattened.cumsum(axis=0)
 
-            elif self.order == ArrayEncodingType.COL_MAJOR:
-                ciphertext = EvalSumCumCols(self.data, self.nrows)
+            ciphertexts = [
+                self._get_element_2D(row, col)
+                for row in range(self.original_shape[0])
+                for col in range(self.original_shape[1])
+            ]
+            return self._cta_from_1d(
+                ciphertexts,
+                frame_rows=next_power_of_two(len(ciphertexts)),
+            ).cumsum(axis=0)
 
-            else:
-                raise ONPError(f"Not support this packing order [{self.order}].")
-
-        # cumsum over cols
-        elif axis == 1:
-            if self.order == ArrayEncodingType.ROW_MAJOR:
-                ciphertext = EvalSumCumCols(self.data, self.ncols)
-
-            elif self.order == ArrayEncodingType.COL_MAJOR:
-                ciphertext = EvalSumCumRows(self.data, self.nrows, self.original_shape[0])
-
-            else:
-                raise ONPError(f"Not support this packing order[{self.order}].")
+        lane_size, num_lanes, _ = _get_cumsum_lane_parameters(
+            self,
+            normalized_axis,
+        )
+        if normalized_axis == 0:
+            active_rows = lane_size
+            participating_cols = num_lanes
         else:
-            raise ONPError(f"Invalid axis [{axis}].")
-        return CTArray(ciphertext, original_shape, self.batch_size, shape, order)
+            active_rows = num_lanes
+            participating_cols = lane_size
+
+        frame_rows, frame_cols = self.shape
+        ciphertext = EvalCumSum(
+            self.data,
+            frame_rows,
+            frame_cols,
+            active_rows,
+            participating_cols,
+            self.geometry.repeats,
+            normalized_axis,
+            self.order,
+            self.batch_size,
+        )
+
+        if self.ndim == 0:
+            return CTArray(
+                data=ciphertext,
+                original_shape=(1,),
+                batch_size=self.batch_size,
+                new_shape=(1, 1),
+                order=self.order,
+                geometry=self.geometry,
+            )
+        return self.clone(data=ciphertext)
 
     def apply(self, func: Callable, *args: Any, **kwargs: Any) -> "CTArray":
         """Apply a ciphertext-level function to the underlying ciphertext.

--- a/openfhe_numpy/tensor/ptarray.py
+++ b/openfhe_numpy/tensor/ptarray.py
@@ -56,6 +56,7 @@ class PTArray(FHETensor[Plaintext]):
             self.batch_size,
             self.shape,
             self.order,
+            geometry=self.geometry,
         )
 
     def decrypt(self, *args, **kwargs):
@@ -75,10 +76,3 @@ class PTArray(FHETensor[Plaintext]):
 
     def __repr__(self) -> str:
         return f"PTArray(meta={self.info})"
-
-    def serialize(self) -> dict:
-        raise NotImplementedError("Serialize not implemented for plaintext")
-
-    @classmethod
-    def deserialize(cls, obj: dict) -> "PTArray":
-        raise NotImplementedError("Deserialize not implemented for plaintext")

--- a/openfhe_numpy/tensor/tensor.py
+++ b/openfhe_numpy/tensor/tensor.py
@@ -32,7 +32,7 @@
 # Standard Library Imports
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
-from typing import overload, Any, Dict, Generic, Optional, Tuple, TypeVar, Union
+from typing import overload, Any, Dict, Generic, Literal, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 
@@ -92,14 +92,24 @@ class BaseTensor(ABC, Generic[TPL]):
 # -----------------------------------------------------------
 # FHETensor - Generic Tensor with Metadata
 # -----------------------------------------------------------
+@dataclass(frozen=True)
+class FramePacking:
+    """Physical participation metadata for one packed vector or matrix frame."""
+
+    active: tuple[int, int]
+    padding: Literal["tile", "zero"]
+    repeats: int
+
+
 @dataclass
 class PackedArrayInformation:
     data: list | np.ndarray | TPL
-    original_shape: tuple[int, int]
+    original_shape: tuple[int, ...]
     ndim: int
     batch_size: int
     shape: tuple[int, int]
     order: int
+    geometry: FramePacking | None = None
 
 
 class FHETensor(BaseTensor[TPL], Generic[TPL]):
@@ -130,6 +140,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         "_batch_size",
         "_ndim",
         "_order",
+        "_geometry",
         "_dtype",
         "extra",
     )
@@ -138,10 +149,12 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     def __init__(
         self,
         data: TPL,
-        original_shape: Tuple[int, int],
+        original_shape: Tuple[int, ...],
         batch_size: int,
         new_shape: Tuple[int, int],
         order: int = 0,
+        *,
+        geometry: FramePacking | None = None,
     ) -> None: ...
 
     @overload
@@ -150,12 +163,13 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
     def __init__(
         self,
         data: Union[list, np.ndarray, PackedArrayInformation],
-        original_shape: Tuple[int, int],
+        original_shape: Tuple[int, ...],
         batch_size: int,
         new_shape: Tuple[int, int],
         order: int = 0,
+        *,
+        geometry: FramePacking | None = None,
     ) -> None:
-
         if isinstance(data, PackedArrayInformation):
             self._data = data.data
             self._original_shape = data.original_shape
@@ -163,6 +177,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             self._batch_size = data.batch_size
             self._ndim = data.ndim
             self._order = data.order
+            self._geometry = data.geometry
             self._dtype = self.__class__.__name__
             self.extra = {}
         else:
@@ -179,6 +194,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             if self._ndim > 2 or self._ndim < 0:
                 raise ONPError("Dimension is invalid!!!")
             self._order = order
+            self._geometry = geometry
             self._dtype = self.__class__.__name__
             self._zeros = None
             self.extra = {}
@@ -282,6 +298,11 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             raise ONPError(f"Not support order [f{order}]")
 
     @property
+    def geometry(self) -> FramePacking | None:
+        """Packed-frame participation metadata, when available."""
+        return self._geometry
+
+    @property
     def info(self) -> Dict[str, Any]:
         """Metadata dict for serialization or inspection."""
         return {
@@ -323,6 +344,7 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
             self.batch_size,
             self.shape,
             self.order,
+            geometry=self.geometry,
         )
         result.extra.update(self.extra)
         return result
@@ -382,16 +404,6 @@ class FHETensor(BaseTensor[TPL], Generic[TPL]):
         Sum tensor entries over all elements or one axis.
         Remark: Tuple axes are not supported
         """
-        if axis is not None:
-            if not isinstance(axis, int):
-                raise TypeError(f"axis must be None or an integer, got {type(axis).__name__}.")
-
-            if axis < 0:
-                axis += self.ndim
-
-            if axis < 0 or axis >= self.ndim:
-                raise ValueError(f"Invalid axis {axis} for tensor with {self.ndim} dimensions.")
-
         return self.__tensor_function__(
             "sum",
             (self,),

--- a/openfhe_numpy/utils/_helper_slots_ops.py
+++ b/openfhe_numpy/utils/_helper_slots_ops.py
@@ -1,5 +1,37 @@
 from operator import index as operator_index
 
+from .packing import _is_col_major, _is_row_major
+
+
+def _get_slot_index(row, col, shape, order) -> int:
+    """Return the slot index for ``(row, col)`` within one packed frame."""
+    row = operator_index(row)
+    col = operator_index(col)
+    num_rows, num_cols = shape
+
+    if not (0 <= row < num_rows and 0 <= col < num_cols):
+        raise IndexError(f"matrix position ({row}, {col}) is outside packed shape {shape}.")
+    if _is_row_major(order):
+        return row * num_cols + col
+    if _is_col_major(order):
+        return col * num_rows + row
+    raise ValueError(f"unsupported packing order {order!r}.")
+
+
+def _get_cell_index(slot, shape, order) -> tuple[int, int]:
+    """Return ``(row, col)`` for a slot within one packed frame."""
+    slot = operator_index(slot)
+    num_rows, num_cols = shape
+
+    if not 0 <= slot < num_rows * num_cols:
+        raise IndexError(f"slot index {slot} is outside packed shape {shape}.")
+    if _is_row_major(order):
+        return divmod(slot, num_cols)
+    if _is_col_major(order):
+        col, row = divmod(slot, num_rows)
+        return row, col
+    raise ValueError(f"unsupported packing order {order!r}.")
+
 
 def _create_masking(indices, size):
     """
@@ -22,7 +54,8 @@ def _get_single_element(cc, x, idx, batch_size):
     mask = _create_masking([idx], batch_size)
     pt_mask = cc.MakeCKKSPackedPlaintext(mask)
     ct_res = cc.EvalMult(x, pt_mask)
-    ct_res = cc.EvalRotate(ct_res, idx)
+    if idx:
+        ct_res = cc.EvalRotate(ct_res, idx)
     return ct_res
 
 

--- a/openfhe_numpy/utils/packing.py
+++ b/openfhe_numpy/utils/packing.py
@@ -133,7 +133,9 @@ def _pack_vector_row_wise(
         raise ONPError(f"Padded vector [{nrows} x{ncols}] is longer than the batch size [{batch_size}]")
 
     flattened = np.zeros(expanded_size, dtype=np.asarray(vector).dtype)
-    if expand == "tile":
+    if target_cols is None:
+        flattened[:n] = vector
+    elif expand == "tile":
         if pad_value == "zero":
             for i in range(n):
                 flattened[i * ncols : i * ncols + target_cols] = vector[i]
@@ -143,7 +145,7 @@ def _pack_vector_row_wise(
         else:
             raise ONPError(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
     elif expand == "zero":
-        flattened[np.arange(n) * target_cols] = vector
+        flattened[np.arange(n) * ncols] = vector
     else:
         raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
@@ -235,14 +237,19 @@ def _pack_vector_col_wise(
     padded[:n] = vector
     flattened = np.zeros(expanded_size, dtype=padded.dtype)
 
-    if expand == "tile":
+    if target_cols is None:
+        flattened[:n] = vector
+    elif expand == "tile":
         if pad_value == "tile":
             flattened = np.tile(padded, ncols)
         elif pad_value == "zero":
             for col in range(target_cols):
-                flattened[col::ncols] = padded
+                start = col * nrows
+                flattened[start : start + nrows] = padded
+        else:
+            raise ONPError(f"Invalid pad_value: '{pad_value}'. Valid options are 'zero' or 'tile'.")
     elif expand == "zero":
-        flattened[: n * ncols : ncols] = vector
+        flattened[:n] = vector
     else:
         raise ONPError(f"Invalid expand mode: '{expand}'. Valid options are 'zero' or 'tile'.")
 
@@ -598,10 +605,34 @@ def process_packed_data(
     ndarray
         Reshaped array to its desired shape
     """
-    if info["ndim"] == 2:
-        return _extract_matrix(data, info)
+    raw = np.asarray(data)
+    ndim = info["ndim"]
+    original_shape = tuple(info["original_shape"])
+    shape = tuple(info["shape"])
+    order = info["order"]
+
+    if ndim == 0:
+        values = np.asarray(raw[0]).reshape(())
+    elif ndim == 1:
+        if len(shape) == 1:
+            values = raw[: original_shape[0]]
+        else:
+            values = [
+                raw[row * shape[1] if order == ArrayEncodingType.ROW_MAJOR else row]
+                for row in range(original_shape[0])
+            ]
+    elif ndim == 2:
+        frame = np.reshape(
+            raw[: shape[0] * shape[1]],
+            shape,
+            order="C" if order == ArrayEncodingType.ROW_MAJOR else "F",
+        )
+        values = frame[: original_shape[0], : original_shape[1]]
     else:
-        return _extract_vector(data, info)
+        raise ONPError(f"Unsupported packed rank {ndim}.")
+    return np.asarray(values)
+
+
 def _is_row_major(order: Any) -> bool:
     """Return True if ``order`` is row-major packing."""
     return order == ArrayEncodingType.ROW_MAJOR


### PR DESCRIPTION
Closes #85

## Summary

Fix `cumsum` for packed and block ciphertext tensors.

- Handle row-major and column-major layouts, padding, repeated frames, and partial blocks.
- Implement cumulative carry between blocks.
- Support NumPy-style vector and matrix axes, including C-order `axis=None`.
- Add geometry-aware rotation-key generation with `gen_cumsum_key` and `gen_block_cumsum_keys`.
- Align ciphertext levels and scales for block carry addition. (FIXEDMANUAL)

## Validation

Covered direct and block tensors across packing orders, axes, padding modes, and partial blocks.