### PR TITLE
Fix assorted bugs

### DIFF
--- a/examples/python/block_tensor/simple_block_matrix_cumsum.py
+++ b/examples/python/block_tensor/simple_block_matrix_cumsum.py
@@ -33,15 +33,11 @@ def main():
 
     Operations shown:
       - 1-D cumulative sum across multiple ciphertext blocks
-      - 2-D row-wise cumulative sum along axis=1
+      - 2-D cumulative sum across matrix block rows along axis=0
+      - 2-D cumulative sum across matrix block columns along axis=1
 
-    For a 1-D block vector, the total from each block is carried into the next
-    block.
-
-    For a 2-D block matrix, the cumulative axis must currently stay inside each
-    block. The matrix below has grid_shape=(4, 1), so axis=1 is supported because
-    there is only one block column. axis=0 would cross block rows and is not yet
-    supported.
+    In both cases, the terminal cumulative value from one block is carried into
+    the next block along the cumulative axis.
     """
 
     # --- Cryptographic setup -------------------------------------------------
@@ -70,7 +66,7 @@ def main():
     # --- Inputs --------------------------------------------------------------
     # Both inputs contain more entries than one ciphertext can hold.
     vector = np.arange(1, 41, dtype=float)
-    matrix = np.arange(1, 65, dtype=float).reshape(16, 4)
+    matrix = np.arange(1, 65, dtype=float).reshape(8, 8)
 
     print(f"\nCKKS ring dimension : {cc.GetRingDimension()}")
     print(f"Slots per ciphertext: {batch_size}")
@@ -88,9 +84,8 @@ def main():
     print(matrix)
 
     # --- Build encrypted block tensors ---------------------------------------
-    # Cumsum depth grows with the local block length. Using blocks of length 8
-    # keeps the required depth manageable and produces five ciphertext blocks.
     vector_block_shape = (8,)
+    matrix_block_shape = (4, 4)
 
     ctv = onp.block_array(
         cc=cc,
@@ -98,29 +93,23 @@ def main():
         batch_size=batch_size,
         block_shape=vector_block_shape,
         order=onp.ROW_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
     )
 
-    # Auto-selection gives block_shape=(4, 4) and grid_shape=(4, 1).
     ctm = onp.block_array(
         cc=cc,
         data=matrix,
         batch_size=batch_size,
-        block_shape=None,
+        block_shape=matrix_block_shape,
         order=onp.ROW_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
     )
 
-    # The 1-D path uses EvalSum to obtain each block's total.
-    onp.gen_sum_key(keys.secretKey)
-
-    # Generate the rotation keys needed by cumulative sums inside each block.
-    onp.gen_accumulate_cols_key(keys.secretKey, ctv.block_shape[0])
-    onp.gen_accumulate_cols_key(keys.secretKey, ctm.block_shape[1])
+    onp.gen_block_cumsum_keys(keys.secretKey, ctv)
+    onp.gen_block_cumsum_keys(keys.secretKey, ctm, axis=0)
+    onp.gen_block_cumsum_keys(keys.secretKey, ctm, axis=1)
 
     print_block_metadata("Encrypted block vector", ctv)
     print_block_metadata("Encrypted block matrix", ctm)
@@ -139,8 +128,21 @@ def main():
     )
     all_ok = all_ok and is_match
 
-    # 2) Row-wise matrix cumsum.
-    # grid_shape[1] == 1, so axis=1 never crosses a block boundary.
+    # 2) Matrix cumsum down each column, across both block rows.
+    # axis=0 means that values accumulate from top to bottom.
+    res_matrix = onp.cumsum(ctm, axis=0).decrypt(
+        keys.secretKey,
+        unpack_type="original",
+    )
+    is_match, _ = validate_and_print_results(
+        res_matrix,
+        np.cumsum(matrix, axis=0),
+        "Block matrix cumulative sum (axis=0)",
+    )
+    all_ok = all_ok and is_match
+
+    # 3) Matrix cumsum across each row, across both block columns.
+    # axis=1 means that values accumulate from left to right.
     res_matrix = onp.cumsum(ctm, axis=1).decrypt(
         keys.secretKey,
         unpack_type="original",

--- a/examples/python/block_tensor/simple_block_matrix_vector_product.py
+++ b/examples/python/block_tensor/simple_block_matrix_vector_product.py
@@ -38,8 +38,8 @@ def main():
 
     The block_shape=(2, 2) splits the matrix across multiple ciphertext
     blocks, each holding a 2x2 sub-matrix in batch_size=4 slots.
-    compact=True on the vector produces the duplicated, square-compatible
-    packing required for block matvec; do NOT use compact for plain
+    target_cols=2 expands the vector into the matrix-compatible frame required
+    for block matvec; omit target_cols for plain
     vector arithmetic (add/sub/dot).
     """
 
@@ -101,9 +101,9 @@ def main():
     #
     #   1 2 3 0 | 4 5 6 0   (two 2x2 blocks packed as [row0|row1])
     #
-    # The vector is encoded with compact=True (duplicated packing):
+    # The vector is expanded to target_cols=2:
     #
-    #   1 1 1 1 | 0 0 0 0   (compact COL_MAJOR block vector)
+    #   1 1 1 1 | 0 0 0 0   (expanded COL_MAJOR block vector)
     #
     # The result lands in ROW_MAJOR order, one entry per row of the matrix.
 
@@ -113,22 +113,20 @@ def main():
         batch_size=batch_size,
         block_shape=block_shape,
         order=onp.ROW_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
     )
 
-    # compact=True: produce duplicated block packing required by block matvec.
+    # target_cols matches the matrix block's physical row count.
     ctv_cm = onp.block_array(
         cc=cc,
         data=vector,
         batch_size=batch_size,
-        block_shape=None,
+        block_shape=(block_shape[1],),
         order=onp.COL_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
-        compact=True,
+        target_cols=block_shape[0],
     )
 
     # Attach summation keys to every matrix block before the product.
@@ -136,7 +134,7 @@ def main():
     onp.attach_block_matvec_keys(ctm_rm, keys.secretKey)
 
     print_block_metadata("Block matrix (ROW_MAJOR)", ctm_rm)
-    print_block_metadata("Block vector (COL_MAJOR, compact)", ctv_cm)
+    print_block_metadata("Block vector (COL_MAJOR, expanded)", ctv_cm)
 
     ctv_result_rm = ctm_rm @ ctv_cm
     res_rm = ctv_result_rm.decrypt(keys.secretKey, unpack_type="original")
@@ -152,7 +150,7 @@ def main():
     # =========================================================
     #
     # Column-wise packing interleaves the matrix columns across slots.
-    # The vector uses compact=True (ROW_MAJOR), producing duplicated
+    # The vector uses target_cols=2 (ROW_MAJOR), producing expanded
     # per-element blocks compatible with the COL_MAJOR matrix blocks.
     #
     # The result lands in COL_MAJOR order, one entry per row of the matrix.
@@ -163,22 +161,20 @@ def main():
         batch_size=batch_size,
         block_shape=block_shape,
         order=onp.COL_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
     )
 
-    # compact=True: produce duplicated block packing required by block matvec.
+    # target_cols matches the matrix block's physical row count.
     ctv_rm = onp.block_array(
         cc=cc,
         data=vector,
         batch_size=batch_size,
-        block_shape=None,
+        block_shape=(block_shape[1],),
         order=onp.ROW_MAJOR,
-        mode="zero",
         fhe_type="C",
         public_key=keys.publicKey,
-        compact=True,
+        target_cols=block_shape[0],
     )
 
     # Attach summation keys to every matrix block before the product.
@@ -186,7 +182,7 @@ def main():
     onp.attach_block_matvec_keys(ctm_cm, keys.secretKey)
 
     print_block_metadata("Block matrix (COL_MAJOR)", ctm_cm)
-    print_block_metadata("Block vector (ROW_MAJOR, compact)", ctv_rm)
+    print_block_metadata("Block vector (ROW_MAJOR, expanded)", ctv_rm)
 
     ctv_result_cm = ctm_cm @ ctv_rm
     res_cm = ctv_result_cm.decrypt(keys.secretKey, unpack_type="original")

--- a/examples/python/simple_convolution.py
+++ b/examples/python/simple_convolution.py
@@ -1,6 +1,5 @@
 import numpy as np
-from openfhe import CCParamsCKKSRNS, FIXEDAUTO, \
-  HYBRID, GenCryptoContext, PKESchemeFeature
+from openfhe import CCParamsCKKSRNS, FIXEDAUTO, HYBRID, GenCryptoContext, PKESchemeFeature
 import openfhe_numpy as onp
 
 
@@ -26,7 +25,7 @@ def get_next_power_of_two(n: int) -> int:
     return p
 
 
-def numpy_conv1d(signal, kernel, mode='valid'):
+def numpy_conv1d(signal, kernel, mode="valid"):
     """
     Compute 1D convolution using NumPy.
 
@@ -62,10 +61,10 @@ def validate_and_print_results(computed, expected, operation_name):
     difference = expected - computed
     squared_difference = difference**2
     mse = np.mean(squared_difference)
-    print(f"\nMean Squared Error (MSE): " f"{mse}")
+    print(f"\nMean Squared Error (MSE): {mse}")
 
 
-def openfhe_conv1d(signal, kernel, cc, keys, batch_size, mode='valid'):
+def openfhe_conv1d(signal, kernel, cc, keys, batch_size, mode="valid"):
     """
     Compute 1D convolution using OpenFHE-NumPy.
 
@@ -80,9 +79,11 @@ def openfhe_conv1d(signal, kernel, cc, keys, batch_size, mode='valid'):
     Returns:
         Decrypted convolved signal
     """
-    if mode != 'valid':
-        raise NotImplementedError("Only 'valid' mode implemented \
-          for OpenFHE convolution")
+    if mode != "valid":
+        raise NotImplementedError(
+            "Only 'valid' mode implemented \
+          for OpenFHE convolution"
+        )
 
     signal_len = len(signal)
     kernel_len = len(kernel)
@@ -156,8 +157,7 @@ def openfhe_conv1d(signal, kernel, cc, keys, batch_size, mode='valid'):
             mode="zero",
             public_key=keys.publicKey,
         )
-        onp_ct_convolution_result = onp_ct_convolution_result + \
-            onp_pt_mask * sum_term_j
+        onp_ct_convolution_result = onp_ct_convolution_result + onp_pt_mask * sum_term_j
 
     # Decryption
     decrypted_array = onp_ct_convolution_result.decrypt(keys.secretKey)
@@ -190,7 +190,8 @@ def main():
     params = CCParamsCKKSRNS()
     params.SetScalingModSize(scale_mod_size)
     params.SetFirstModSize(60)
-    params.SetMultiplicativeDepth(2)
+    # Two multiplications plus one level for FIXEDAUTO alignment.
+    params.SetMultiplicativeDepth(3)
     params.SetBatchSize(get_next_power_of_two(signal_length))
     params.SetScalingTechnique(FIXEDAUTO)
     params.SetKeySwitchTechnique(HYBRID)
@@ -204,7 +205,7 @@ def main():
     cc.EvalMultKeyGen(keys.secretKey)
     cc.EvalSumKeyGen(keys.secretKey)
 
-    rotations = list(range(-(signal_length-kernel_length+1), 1, 1))
+    rotations = list(range(-(signal_length - kernel_length + 1), 1, 1))
     cc.EvalRotateKeyGen(keys.secretKey, rotations)
 
     ring_dim = cc.GetRingDimension()
@@ -213,22 +214,24 @@ def main():
     print(f"Available slots: {batch_size}")
 
     if signal_length > batch_size:
-        print(f"Warning: Signal length {signal_length} \
-            is larger than available slots {batch_size}.")
-        print("The signal will be truncated or \
-            wrapped around by openfhe-numpy.")
+        print(
+            f"Warning: Signal length {signal_length} \
+            is larger than available slots {batch_size}."
+        )
+        print(
+            "The signal will be truncated or \
+            wrapped around by openfhe-numpy."
+        )
 
     # Convolution
     try:
         # Compute ground truth result using numpy (unencrypted)
-        expected_conv = numpy_conv1d(signal, kernel, mode='valid')
+        expected_conv = numpy_conv1d(signal, kernel, mode="valid")
 
         # Compute convolution with OpenFHE (encrypted)
-        openfhe_result = openfhe_conv1d(signal, kernel, cc,
-                                        keys, batch_size, mode='valid')
+        openfhe_result = openfhe_conv1d(signal, kernel, cc, keys, batch_size, mode="valid")
 
-        validate_and_print_results(openfhe_result, expected_conv,
-                                   "OpenFHE Convolution")
+        validate_and_print_results(openfhe_result, expected_conv, "OpenFHE Convolution")
 
     except Exception as e:
         print(f"Error in OpenFHE convolution: {e}")

--- a/examples/python/simple_matrix_accumulation.py
+++ b/examples/python/simple_matrix_accumulation.py
@@ -18,13 +18,8 @@ def validate_and_print_results(computed, expected, operation_name):
 def run_row_accumulation_example(cc, keys, ctm_x, matrix):
     """Run homomorphic row accumulation example."""
 
-    # Generate rotation keys for row operations
-    if ctm_x.order == onp.ROW_MAJOR:
-        onp.gen_accumulate_rows_key(keys.secretKey, ctm_x.ncols)
-    elif ctm_x.order == onp.COL_MAJOR:
-        onp.gen_accumulate_cols_key(keys.secretKey, ctm_x.nrows)
-    else:
-        raise ValueError("Invalid order.")
+    # Generate the exact rotations used by this packed geometry and axis.
+    onp.gen_cumsum_key(keys.secretKey, ctm_x, axis=0)
 
     # Perform homomorphic row accumulation
     ctm_result = onp.cumsum(ctm_x, axis=0)
@@ -41,13 +36,7 @@ def run_row_accumulation_example(cc, keys, ctm_x, matrix):
 def run_column_accumulation_example(cc, keys, ctm_x, matrix):
     """Run homomorphic column accumulation example."""
 
-    # Generate rotation keys for column operations
-    if ctm_x.order == onp.ROW_MAJOR:
-        onp.gen_accumulate_cols_key(keys.secretKey, ctm_x.ncols)
-    elif ctm_x.order == onp.COL_MAJOR:
-        onp.gen_accumulate_rows_key(keys.secretKey, ctm_x.nrows)
-    else:
-        raise ValueError("Invalid order.")
+    onp.gen_cumsum_key(keys.secretKey, ctm_x, axis=1)
 
     # Perform homomorphic column accumulation
     ctm_result = onp.cumsum(ctm_x, axis=1)

--- a/examples/python/simple_mlp_inference.py
+++ b/examples/python/simple_mlp_inference.py
@@ -228,7 +228,7 @@ def onp_forward_pass(X, W1, b1, W2, b2, cc, keys, batch_size):
         cc=cc,
         data=b2_square_zero_padded,
         batch_size=batch_size,
-        order=onp.COL_MAJOR,
+        order=onp.ROW_MAJOR,
         fhe_type="C",
         mode="tile",
         public_key=keys.publicKey,
@@ -324,4 +324,3 @@ if __name__ == '__main__':
     print(f"\nonp_forward_pass took {elapsed_time:.4f} seconds.")
     
     validate_and_print_results(onp_probabilities[0][0], np_probabilities[0][0], "MLP")
-    

--- a/examples/python/simple_mlp_inference_unencrypted_weights.py
+++ b/examples/python/simple_mlp_inference_unencrypted_weights.py
@@ -227,7 +227,7 @@ def onp_forward_pass(X, W1, b1, W2, b2, cc, keys, batch_size):
         cc=cc,
         data=b2,
         batch_size=batch_size,
-        order=onp.COL_MAJOR,
+        order=onp.ROW_MAJOR,
         fhe_type="P",
         mode="tile",
         public_key=keys.publicKey,
@@ -311,4 +311,3 @@ if __name__ == '__main__':
     print(f"\nonp_forward_pass took {elapsed_time:.4f} seconds.")
     
     validate_and_print_results(onp_probabilities[0][0], np_probabilities[0][0], "MLP")
-    

--- a/examples/python/tests.py
+++ b/examples/python/tests.py
@@ -37,7 +37,7 @@ ctm_a = onp.array(
 )
 print("ctm_a.ncols (padded):", ctm_a.ncols, "original_shape:", ctm_a.original_shape)
 
-onp.gen_accumulate_rows_key(keys.secretKey, ctm_a.ncols)
+onp.gen_cumsum_key(keys.secretKey, ctm_a, axis=0)
 
 try:
     res = ctm_a.cumsum(axis=0)
@@ -49,7 +49,7 @@ except Exception as e:
 
 
 # ------------------------------------------------------------------
-# R1: 1-D vector cumsum -- this is the one that actually crashes.
+# 1-D vector cumsum.
 # ------------------------------------------------------------------
 print("\n--- 1-D vector cumsum ---")
 v = np.array([1.0, 2.0, 3.0, 4.0])
@@ -69,10 +69,10 @@ print(
     "ctm_v.ndim:", ctm_v.ndim, "ctm_v.ncols:", ctm_v.ncols, "original_shape:", ctm_v.original_shape
 )
 
-onp.gen_accumulate_cols_key(keys.secretKey, ctm_v.ncols)
+onp.gen_cumsum_key(keys.secretKey, ctm_v)
 
 try:
-    res_v = ctm_v.cumsum()  # default axis=0 -- same crash as axis=None
+    res_v = ctm_v.cumsum()
     decrypted_v = res_v.decrypt(keys.secretKey, unpack_type="original")
     print("cumsum() result:", decrypted_v)
 except Exception as e:

--- a/openfhe_numpy/operations/arithmetic_utils.py
+++ b/openfhe_numpy/operations/arithmetic_utils.py
@@ -42,7 +42,10 @@ from typing import Any
 import numpy as np
 
 from openfhe_numpy.openfhe_numpy import ArrayEncodingType
-from openfhe_numpy.operations.broadcast import broadcast_to
+from openfhe_numpy.operations.broadcast import (
+    _broadcast_to_physical_slots,
+    broadcast_to,
+)
 from openfhe_numpy.tensor.tensor import BaseTensor
 from openfhe_numpy.utils.errors import (
     ONPDimensionError,
@@ -300,10 +303,29 @@ def _align_binary_operands(a, b):
     )
 
     crypto_context = _binary_crypto_context(a, b)
-    if source_a != output_shape:
-        a = broadcast_to(a, output_shape, order=a.order, cc=crypto_context)
-    if source_b != output_shape:
-        b = broadcast_to(b, output_shape, order=b.order, cc=crypto_context)
+    matrix_result = len(output_shape) == 2
+    if matrix_result and source_a == output_shape:
+        if source_b != output_shape:
+            b = _broadcast_to_physical_slots(
+                b,
+                logical_shape=output_shape,
+                physical_shape=a.shape,
+                order=a.order,
+                cc=crypto_context,
+            )
+    elif matrix_result and source_b == output_shape:
+        a = _broadcast_to_physical_slots(
+            a,
+            logical_shape=output_shape,
+            physical_shape=b.shape,
+            order=b.order,
+            cc=crypto_context,
+        )
+    else:
+        if source_a != output_shape:
+            a = broadcast_to(a, output_shape, order=a.order, cc=crypto_context)
+        if source_b != output_shape:
+            b = broadcast_to(b, output_shape, order=b.order, cc=crypto_context)
 
     _require(
         tuple(a.shape) == tuple(b.shape),

--- a/openfhe_numpy/operations/block_arithmetic_utils.py
+++ b/openfhe_numpy/operations/block_arithmetic_utils.py
@@ -41,7 +41,7 @@ from openfhe_numpy.utils.errors import (
     ONPValueError,
 )
 from openfhe_numpy.utils.typecheck import Number
-from openfhe_numpy.utils.matlib import _sum_terms
+from openfhe_numpy.utils.matlib import _sum_terms, is_power_of_two
 from openfhe_numpy.operations.arithmetic_utils import (
     _eval_binary,
     _eval_scalar_binary,
@@ -269,10 +269,10 @@ def _assert_block_matmul_compatible(a: BlockFHETensor, b: BlockFHETensor) -> Non
     block_rows, block_cols = a.block_shape
 
     _require(
-        block_rows == block_cols,
+        block_rows == block_cols and is_power_of_two(block_rows),
         a.block_shape,
         b.block_shape,
-        "Block matmul requires square blocks.",
+        "Block matmul requires a square power-of-two block_shape.",
     )
     _require(
         a.batch_size == b.batch_size,

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -46,12 +46,14 @@ from .dispatch import register_tensor_function
 
 
 from openfhe_numpy.tensor.ctarray import CTArray
+from openfhe_numpy.tensor.tensor import FramePacking
 from openfhe_numpy.utils.errors import (
     ONPError,
     ONPIncompatibleShapeError,
     ONPNotSupportedError,
     ONPValueError,
     ONPDimensionError,
+    _require,
 )
 from openfhe_numpy.openfhe_numpy import (
     ArrayEncodingType,
@@ -178,15 +180,38 @@ def _eval_matvec_ct(lhs, rhs):
 
 
 def _matmul_ct(lhs, rhs):
-    """Internal function to evaluate matrix multiplication."""
+    """Multiply matrices stored in matching square physical frames."""
     # matrix @ matrix
-    if lhs.ndim == 2 and lhs.original_shape == rhs.original_shape:
+    if lhs.ndim == 2 and rhs.ndim == 2:
+        _require(
+            lhs.original_shape[1] == rhs.original_shape[0],
+            lhs.original_shape,
+            rhs.original_shape,
+            "Matrix multiplication requires matching inner dimensions.",
+        )
+        _require(
+            lhs.shape == rhs.shape and lhs.nrows == lhs.ncols,
+            lhs.shape,
+            rhs.shape,
+            "Matrix multiplication requires matching square physical frames.",
+            error_cls=ONPValueError,
+        )
+        result_shape = (lhs.original_shape[0], rhs.original_shape[1])
+        geometry = None
+        if lhs.geometry is not None and rhs.geometry is not None:
+            geometry = FramePacking(
+                active=result_shape,
+                padding="zero",
+                repeats=min(lhs.geometry.repeats, rhs.geometry.repeats),
+            )
+
         return CTArray(
             EvalMatMulSquare(lhs.data, rhs.data, lhs.ncols),
-            lhs.original_shape,
+            result_shape,
             lhs.batch_size,
             lhs.shape,
             lhs.order,
+            geometry=geometry,
         )
 
     # matrix @ vector
@@ -194,7 +219,8 @@ def _matmul_ct(lhs, rhs):
         return _eval_matvec_ct(lhs, rhs)
     else:
         raise ValueError(
-            f"Dimension mismatch for multiplication ({lhs.original_shape} @ {rhs.original_shape})"
+            f"Dimension mismatch for multiplication "
+            f"({lhs.original_shape} @ {rhs.original_shape})"
         )
 
 

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -426,20 +426,37 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
         # Sum across each row of a packed_encoded matrix ciphertext: fhe_data
         if order == ArrayEncodingType.ROW_MAJOR:
             ct_sum = cc.EvalSumRows(fhe_data, ncols, x.extra["rowkey"], 0)
-            padded_shape = x.shape
-            order = ArrayEncodingType.COL_MAJOR
+            input_repeats = x.geometry.repeats if x.geometry is not None else 1
+            if input_repeats > 1:
+                ct_sum = cc.EvalMult(ct_sum, 1.0 / input_repeats)
+
+            active = (1, cols) if keepdims else (cols, 1)
+            shape = active if keepdims else (cols,)
+            padded_shape = (1, ncols) if keepdims else (ncols, 1)
+            return CTArray(
+                ct_sum,
+                shape,
+                x.batch_size,
+                padded_shape,
+                order,
+                geometry=FramePacking(
+                    active=active,
+                    padding="zero",
+                    repeats=x.batch_size // ncols,
+                ),
+            )
         elif order == ArrayEncodingType.COL_MAJOR:
             ct_sum = cc.EvalSumCols(fhe_data, nrows, x.extra["colkey"])
-            padded_shape = (ncols, nrows)
-            order = ArrayEncodingType.ROW_MAJOR
+            if keepdims:
+                shape = (1, cols)
+                padded_shape = x.shape
+            else:
+                shape = (cols,)
+                padded_shape = (ncols, nrows)
+                order = ArrayEncodingType.ROW_MAJOR
 
         else:
             raise ONPNotSupportedError(f"Not support the current encoding [{order}] ")
-
-        if keepdims:
-            shape = (cols, 1)
-        else:
-            shape = (cols,)
 
     elif axis == 1:
         # Sum across each column of a packed_encoded matrix ciphertext: fhe_data


### PR DESCRIPTION
Fixed bug #91 

## Summary

Fix several runtime integration bugs found while validating cumulative sums with matrix operations:

- Support partial boundary blocks in block matrix multiplication.
- Preserve physical frame geometry during arithmetic broadcasting.
- Correct `sum(axis=0)` output shape and packing metadata.
- Prevent tiled frames from being counted multiple times during summation.
- Update cumsum, block matvec, convolution, and MLP examples to match current behavior.


