### PR TITLE
Add order transformation, fix transpose, and sum bug

### DIFF
--- a/examples/python/block_tensor/simple_block_matrix_operation.py
+++ b/examples/python/block_tensor/simple_block_matrix_operation.py
@@ -34,25 +34,22 @@ def main():
     so it *cannot* be packed into a single ciphertext. openfhe-numpy tiles it into a
     grid of small blocks, each of which fits in one ciphertext.
 
-    Operations shown (all elementwise, so any block shape works):
+    Operations shown:
       - block matrix addition (CT + CT)
       - block matrix subtraction (CT - CT)
       - block matrix elementwise multiplication (CT * CT)
       - block matrix scalar multiplication (CT * scalar)
       - block matrix mixed addition (CT + PT)
+      - block matrix transpose with rectangular blocks
+      - packed-order transform followed by addition
     """
 
     # --- Cryptographic setup -------------------------------------------------
     ring_dim = 2**6  # 64
-    mult_depth = 1  # elementwise mul needs depth 1; increase for chained ops
+    mult_depth = 3  # transpose + transform + logical-slot arithmetic
     scale_mod_size = 50
 
-    # block_shape is OPTIONAL. Leave it None and openfhe-numpy auto-selects the
-    # largest square block that fits in one ciphertext:
-    #     side = 2 ** floor((batch_size.bit_length() - 1) / 2),  batch_size = ring_dim // 2
-    # For batch_size = 32 that gives a (4, 4) block. Pass an explicit tuple
-    # (e.g. (4, 4) or (2, 2)) to choose it yourself.
-    block_shape = None
+    block_shape = (2, 4)
 
     params = CCParamsCKKSRNS()
     params.SetRingDim(ring_dim)
@@ -92,9 +89,8 @@ def main():
     print(matrix_b)
 
     # --- Build encrypted block matrices --------------------------------------
-    # With block_shape=None the 8x8 matrix is auto-tiled into a 2x2 grid of (4,4)
-    # blocks; each block is one ciphertext. (Non-divisible sizes zero-pad the edge
-    # blocks.)
+    # The 8x8 matrix is tiled into a 4x2 grid of (2,4) blocks. Each block is one
+    # ciphertext. Non-divisible sizes would zero-pad the edge blocks.
     ctm_a = onp.block_array(
         cc=cc,
         data=matrix_a,
@@ -129,7 +125,7 @@ def main():
     )
 
     print(
-        f"\nAuto-selected block_shape = {ctm_a.block_shape}, "
+        f"\nSelected block_shape = {ctm_a.block_shape}, "
         f"grid_shape = {ctm_a.grid_shape}  ({ctm_a.num_blocks} ciphertext blocks)"
     )
 
@@ -173,6 +169,29 @@ def main():
         res_add_plain, matrix_a + matrix_b, "Block matrix mixed addition (CT + PT)"
     )
     all_ok = all_ok and is_match
+
+    # 6) Transpose a block matrix whose individual blocks are rectangular.
+    onp.gen_block_transpose_keys(keys.secretKey, ctm_a)
+    ctm_transposed = ctm_a.transpose()
+    res_transposed = ctm_transposed.decrypt(keys.secretKey, unpack_type="original")
+    is_match, _ = validate_and_print_results(res_transposed, matrix_a.T, "Block matrix transpose")
+    all_ok = all_ok and is_match
+    print_block_metadata("Transposed block matrix", ctm_transposed)
+
+    # 7) Change the packing order, then continue with ordinary arithmetic.
+    onp.gen_transform_keys(keys.secretKey, ctm_transposed)
+    ctm_col_major = ctm_transposed.transform(onp.COL_MAJOR)
+    res_transformed_add = (ctm_col_major + 2.0).decrypt(
+        keys.secretKey,
+        unpack_type="original",
+    )
+    is_match, _ = validate_and_print_results(
+        res_transformed_add,
+        matrix_a.T + 2.0,
+        "Block transpose + COL_MAJOR transform + scalar addition",
+    )
+    all_ok = all_ok and is_match
+    print_block_metadata("Column-major transposed block matrix", ctm_col_major)
 
     print("\n" + "=" * 60)
     print(f"All checks passed: {all_ok}")

--- a/examples/python/simple_matrix_transpose.py
+++ b/examples/python/simple_matrix_transpose.py
@@ -8,10 +8,11 @@ import openfhe_numpy as onp
 
 def demo():
     """
-    Run a demonstration of homomorphic matrix multiplication using OpenFHE-NumPy.
+    Demonstrate square and rectangular homomorphic matrix transpose.
     """
 
     params = CCParamsCKKSRNS()
+    params.SetMultiplicativeDepth(3)
     cc = GenCryptoContext(params)
     cc.Enable(PKESchemeFeature.PKE)
     cc.Enable(PKESchemeFeature.LEVELEDSHE)
@@ -35,11 +36,7 @@ def demo():
 
     print("Matrix:\n", matrix)
 
-    batch_size = (
-        params.GetBatchSize()
-        if params.GetBatchSize()
-        else cc.GetRingDimension() // 2
-    )
+    batch_size = params.GetBatchSize() if params.GetBatchSize() else cc.GetRingDimension() // 2
 
     # Encrypt matrix A
     ctm_x = onp.array(
@@ -67,6 +64,38 @@ def demo():
     print(f"\nDecrypted Result:\n{result}")
 
     is_match, error = onp.check_equality(result, expected)
+    print(f"\nMatch: {is_match}, Total Error: {error}")
+
+    rectangular_matrix = np.arange(1, 16, dtype=float).reshape(3, 5)
+    print("\n" + "*" * 60)
+    print("* RECTANGULAR TRANSPOSE + ORDER TRANSFORM + ADDITION")
+    print("*" * 60)
+    print(f"\nRectangular matrix:\n{rectangular_matrix}")
+
+    ctm_rectangular = onp.array(
+        cc=cc,
+        data=rectangular_matrix,
+        batch_size=batch_size,
+        order=onp.ROW_MAJOR,
+        fhe_type="C",
+        mode="zero",
+        public_key=keys.publicKey,
+    )
+
+    onp.gen_transpose_keys(keys.secretKey, ctm_rectangular)
+    ctm_rectangular_transposed = ctm_rectangular.transpose()
+
+    # Transform changes only the packed order. The logical matrix is unchanged.
+    onp.gen_transform_keys(keys.secretKey, ctm_rectangular_transposed)
+    ctm_col_major = ctm_rectangular_transposed.transform(onp.COL_MAJOR)
+    ctm_combined = ctm_col_major + 2.0
+
+    combined_result = ctm_combined.decrypt(keys.secretKey)
+    combined_expected = rectangular_matrix.T + 2.0
+    print(f"\nExpected:\n{combined_expected}")
+    print(f"\nDecrypted Result:\n{combined_result}")
+
+    is_match, error = onp.check_equality(combined_result, combined_expected)
     print(f"\nMatch: {is_match}, Total Error: {error}")
 
 

--- a/openfhe_numpy/cpp/examples/demo-single-matrix-operation.cpp
+++ b/openfhe_numpy/cpp/examples/demo-single-matrix-operation.cpp
@@ -277,9 +277,12 @@ void DemoMatrixTranspose() {
 
     TimeVar t;
 
-    // Perform homomorphic transpose
+    // Generate transpose keys separately from evaluation.
+    EvalTransposeKeyGen(keyPair.secretKey, paddedCols);
+
+    // Perform homomorphic transpose.
     TIC(t);
-    auto encryptedTranspose = EvalTranspose(keyPair.secretKey, ctMatA, paddedCols);
+    auto encryptedTranspose = EvalTranspose(ctMatA, paddedCols);
     double timeEval         = TOC(t);
 
     // Decrypt and display results

--- a/openfhe_numpy/cpp/include/numpy_enc_matrix.h
+++ b/openfhe_numpy/cpp/include/numpy_enc_matrix.h
@@ -114,11 +114,17 @@ Ciphertext<DCRTPoly> EvalMatMulSquare(const std::vector<double>& rMatA,
                                       ConstCiphertext<DCRTPoly>& ctMatB,
                                       uint32_t numCols);
 
-Ciphertext<DCRTPoly> EvalTranspose(PrivateKey<DCRTPoly>& secretKey,
-                                  ConstCiphertext<DCRTPoly>& ciphertext,
-                                  uint32_t numCols);
-
 Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext, uint32_t numCols);
+
+Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext,
+                                   uint32_t numRows,
+                                   uint32_t numCols);
+
+void EvalTransposeKeyGen(PrivateKey<DCRTPoly>& secretKey, uint32_t numCols);
+
+void EvalTransposeKeyGen(PrivateKey<DCRTPoly>& secretKey,
+                         uint32_t numRows,
+                         uint32_t numCols);
 
 Ciphertext<DCRTPoly> EvalSumCumRows(ConstCiphertext<DCRTPoly>& ciphertext,
                                           uint32_t numCols,

--- a/openfhe_numpy/cpp/include/numpy_utils.h
+++ b/openfhe_numpy/cpp/include/numpy_utils.h
@@ -41,7 +41,8 @@ std::vector<double> GenSigmaDiag(size_t total_slot, size_t rowsize, int32_t k);
 std::vector<double> GenTauDiag(size_t total_slots, size_t rowsize, int32_t k);
 std::vector<double> GenPhiDiag(size_t total_slot, size_t rowsize, int32_t k, int type);
 std::vector<double> GenPsiDiag(size_t total_slot, size_t rowsize);
-std::vector<double> GenTransposeDiag(size_t total_slots, size_t rowsize, int32_t i);
+std::vector<double> GenTransposeDiag(size_t totalSlots, size_t numCols, int32_t index);
+std::vector<int32_t> GenTransposeRotationIndices(uint32_t numRows, uint32_t numCols);
 void RoundVector(std::vector<double>& vector);
 
 template <typename T>

--- a/openfhe_numpy/cpp/lib/numpy_bindings.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_bindings.cpp
@@ -238,14 +238,29 @@ void bind_matrix_funcs(py::module& m) {
         py::arg("numCols"));
 
     m.def("EvalTranspose",
-        static_cast<Ciphertext<DCRTPoly>(*)(PrivateKey<DCRTPoly>&, ConstCiphertext<DCRTPoly>&, uint32_t)>(&EvalTranspose),
-        py::arg("secretKey"),
+        static_cast<Ciphertext<DCRTPoly>(*)(ConstCiphertext<DCRTPoly>&, uint32_t)>(&EvalTranspose),
         py::arg("ciphertext"),
         py::arg("numCols"));
 
     m.def("EvalTranspose",
-        static_cast<Ciphertext<DCRTPoly>(*)(ConstCiphertext<DCRTPoly>&, uint32_t)>(&EvalTranspose),
+        static_cast<Ciphertext<DCRTPoly>(*)(ConstCiphertext<DCRTPoly>&, uint32_t, uint32_t)>(&EvalTranspose),
         py::arg("ciphertext"),
+        py::arg("numRows"),
+        py::arg("numCols"));
+
+    m.def("EvalTransposeKeyGen",
+        [](PrivateKey<DCRTPoly>& secretKey, uint32_t numCols) {
+            EvalTransposeKeyGen(secretKey, numCols);
+        },
+        py::arg("secretKey"),
+        py::arg("numCols"));
+
+    m.def("EvalTransposeKeyGen",
+        [](PrivateKey<DCRTPoly>& secretKey, uint32_t numRows, uint32_t numCols) {
+            EvalTransposeKeyGen(secretKey, numRows, numCols);
+        },
+        py::arg("secretKey"),
+        py::arg("numRows"),
         py::arg("numCols"));
 
     m.def("EvalSquareMatMultRotateKeyGen",

--- a/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_enc_matrix.cpp
@@ -30,6 +30,7 @@
 //==============================================================================
 
 #include <limits>
+#include <map>
 #include "numpy_enc_matrix.h"
 #include "numpy_utils.h"
 
@@ -777,6 +778,9 @@ Ciphertext<DCRTPoly> EvalMatMulSquare(ConstPlaintext& ptMatA,
                                      uint32_t numCols) {
     return EvalMatMulSquare(ptMatA->GetRealPackedValue(), ctMatB, numCols);
 }
+// -------------------------------------------------------------
+// TRANSPOSE
+// ------------------------------------------------------------
 /**
  * @brief Computes the transpose of a ciphertext matrix using a private key.
  * @param secretKey The private key used for the operation.
@@ -821,6 +825,106 @@ Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext, uint32
         OPENFHE_THROW("EvalTranspose: Homomorphic operation failed. Details: " + std::string(e.what()));
     }
 };
+
+/**
+ * @brief Computes the transpose of a packed ciphertext matrix.
+ * @param ciphertext The input ciphertext matrix.
+ * @param numRows The number of rows in its row-major physical interpretation.
+ * @param numCols The number of columns in its row-major physical interpretation.
+ * @return The packed transpose, interpreted as a numCols x numRows matrix.
+ */
+Ciphertext<DCRTPoly> EvalTranspose(ConstCiphertext<DCRTPoly>& ciphertext,
+                                   uint32_t numRows,
+                                   uint32_t numCols) {
+    try {
+        if (numRows == numCols) {
+            return EvalTranspose(ciphertext, numCols);
+        }
+
+        const auto rotationIndices = GenTransposeRotationIndices(numRows, numCols);
+        const uint32_t matrixSize = numRows * numCols;
+        CryptoContext<DCRTPoly> cc = ciphertext->GetCryptoContext();
+        const uint32_t slots = cc->GetEncodingParams()->GetBatchSize();
+        if (matrixSize > slots || slots % matrixSize != 0) {
+            OPENFHE_THROW("numRows * numCols must divide the ciphertext batch size");
+        }
+
+        Ciphertext<DCRTPoly> ctResult;
+        for (int32_t rotationIndex : rotationIndices) {
+            std::vector<double> diagonalVector(slots, 0.0);
+            for (uint32_t targetSlot = 0; targetSlot < matrixSize; ++targetSlot) {
+                const uint32_t outputRow = targetSlot / numRows;
+                const uint32_t outputCol = targetSlot % numRows;
+                const int32_t sourceSlot = static_cast<int32_t>(outputCol * numCols + outputRow);
+                if (sourceSlot - static_cast<int32_t>(targetSlot) != rotationIndex) {
+                    continue;
+                }
+                for (uint32_t base = 0; base < slots; base += matrixSize) {
+                    diagonalVector[base + targetSlot] = 1.0;
+                }
+            }
+
+            auto ptDiagonal = cc->MakeCKKSPackedPlaintext(diagonalVector);
+            Ciphertext<DCRTPoly> ctProd;
+            if (rotationIndex == 0) {
+                ctProd = cc->EvalMult(ciphertext, ptDiagonal);
+            }
+            else {
+                auto ctRotated = cc->EvalRotate(ciphertext, rotationIndex);
+                ctProd = cc->EvalMult(ctRotated, ptDiagonal);
+            }
+
+            if (!ctResult) {
+                ctResult = ctProd;
+            }
+            else {
+                cc->EvalAddInPlace(ctResult, ctProd);
+            }
+        }
+
+        return ctResult;
+    }
+    catch (const std::exception& e) {
+        OPENFHE_THROW("EvalTranspose: Homomorphic operation failed. Details: " + std::string(e.what()));
+    }
+}
+
+/**
+ * @brief Generates the rotation keys used to transpose square matrices.
+ * @param secretKey The private key used for key generation.
+ * @param numCols The number of rows and columns in each matrix.
+ */
+void EvalTransposeKeyGen(PrivateKey<DCRTPoly>& secretKey, uint32_t numCols) {
+    EvalLinTransKeyGen(secretKey, numCols, LinTransType::TRANSPOSE);
+}
+
+/**
+ * @brief Generates the rotation keys used to transpose rectangular matrices.
+ * @param secretKey The private key used for key generation.
+ * @param numRows The number of rows in the matrix.
+ * @param numCols The number of columns in the matrix.
+ */
+void EvalTransposeKeyGen(PrivateKey<DCRTPoly>& secretKey,
+                         uint32_t numRows,
+                         uint32_t numCols) {
+    if (numRows == numCols) {
+        EvalTransposeKeyGen(secretKey, numCols);
+        return;
+    }
+
+    const auto transposeRotationIndices = GenTransposeRotationIndices(numRows, numCols);
+    std::vector<int32_t> rotationIndices;
+    rotationIndices.reserve(transposeRotationIndices.size());
+    for (int32_t rotationIndex : transposeRotationIndices) {
+        if (rotationIndex != 0) {
+            rotationIndices.push_back(rotationIndex);
+        }
+    }
+    if (!rotationIndices.empty()) {
+        secretKey->GetCryptoContext()->EvalRotateKeyGen(secretKey, rotationIndices);
+    }
+}
+
 // -------------------------------------------------------------
 // EvalSumAccumulate
 // -------------------------------------------------------------

--- a/openfhe_numpy/cpp/lib/numpy_utils.cpp
+++ b/openfhe_numpy/cpp/lib/numpy_utils.cpp
@@ -31,7 +31,9 @@
 #include "numpy_utils.h"
 #include "utils/exception.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 void RoundVector(std::vector<double>& vector) {
     for (double& e : vector)
@@ -193,4 +195,31 @@ std::vector<double> GenTransposeDiag(size_t totalSlots, size_t numCols, int32_t 
         }
     }
     return diag;
+}
+std::vector<int32_t> GenTransposeRotationIndices(uint32_t numRows, uint32_t numCols) {
+    if (numRows == 0 || numCols == 0) {
+        OPENFHE_THROW("numRows and numCols must be positive");
+    }
+
+    const uint64_t matrixSize64 = static_cast<uint64_t>(numRows) * numCols;
+    if (matrixSize64 > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+        OPENFHE_THROW("numRows * numCols is too large");
+    }
+
+    const uint32_t matrixSize = static_cast<uint32_t>(matrixSize64);
+    std::vector<int32_t> rotationIndices;
+    rotationIndices.reserve(matrixSize);
+    for (uint32_t targetSlot = 0; targetSlot < matrixSize; ++targetSlot) {
+        const uint32_t outputRow = targetSlot / numRows;
+        const uint32_t outputCol = targetSlot % numRows;
+        const int32_t sourceSlot = static_cast<int32_t>(outputCol * numCols + outputRow);
+        const int32_t rotationIndex = sourceSlot - static_cast<int32_t>(targetSlot);
+        rotationIndices.push_back(rotationIndex);
+    }
+
+    std::sort(rotationIndices.begin(), rotationIndices.end());
+    rotationIndices.erase(
+        std::unique(rotationIndices.begin(), rotationIndices.end()),
+        rotationIndices.end());
+    return rotationIndices;
 }

--- a/openfhe_numpy/operations/__init__.py
+++ b/openfhe_numpy/operations/__init__.py
@@ -65,6 +65,7 @@ from .crypto_helper import (
     gen_rotation_keys,
     gen_lintrans_keys,
     gen_transpose_keys,
+    gen_transform_keys,
     gen_square_matmult_key,
     gen_accumulate_rows_key,
     gen_accumulate_cols_key,
@@ -106,6 +107,7 @@ __all__ = [
     "gen_accumulate_cols_key",
     "gen_cumsum_key",
     "gen_block_cumsum_keys",
+    "gen_transform_keys",
     # broadcasting operations
     "broadcast_to",
     "generate_broadcast_key",

--- a/openfhe_numpy/operations/arithmetic_utils.py
+++ b/openfhe_numpy/operations/arithmetic_utils.py
@@ -41,7 +41,7 @@ from typing import Any
 
 import numpy as np
 
-from openfhe_numpy.openfhe_numpy import ArrayEncodingType
+from openfhe_numpy.openfhe_numpy import ArrayEncodingType, EvalTranspose
 from openfhe_numpy.operations.broadcast import (
     _broadcast_to_physical_slots,
     broadcast_to,
@@ -145,17 +145,13 @@ def _normalize_axis(
 
     if isinstance(axis, tuple):
         if "tuple" not in supported:
-            raise ONPNotSupportedError(
-                f"{operation} does not support tuple axes."
-            )
+            raise ONPNotSupportedError(f"{operation} does not support tuple axes.")
         raise ONPNotImplementedError(
             f"tuple-axis normalization is not implemented for {operation}."
         )
 
     if "integer" not in supported:
-        raise ONPNotSupportedError(
-            f"{operation} currently supports only axis=None."
-        )
+        raise ONPNotSupportedError(f"{operation} currently supports only axis=None.")
 
     if isinstance(axis, (bool, np.bool_)):
         raise TypeError("axis must be an integer, not boolean.")
@@ -570,3 +566,21 @@ def _eval_binary(a, b, op_name):
     result = encrypted.clone(result_data)
     result.extra.update(other.extra)
     return result
+
+
+# ------------------------------------------------------------------------------
+# Packing order transform
+# ------------------------------------------------------------------------------
+
+
+def _eval_transform(ciphertext, shape, current_order):
+    """Change the packed order of a matrix."""
+    rows, cols = shape
+
+    if rows == 1 or cols == 1:
+        return ciphertext
+
+    if current_order == ArrayEncodingType.COL_MAJOR:
+        rows, cols = cols, rows
+
+    return EvalTranspose(ciphertext, rows, cols)

--- a/openfhe_numpy/operations/crypto_helper.py
+++ b/openfhe_numpy/operations/crypto_helper.py
@@ -208,12 +208,31 @@ def gen_transpose_keys(secret_key: openfhe.PrivateKey, ctm_matrix):
     ctm_matrix : CTArray
         The ciphertext matrix to transpose
     """
-    if ctm_matrix.ndim == 1:
-        ncols = 1
-    else:
-        ncols = ctm_matrix.ncols
+    if ctm_matrix.ndim < 2:
+        return
 
-    backend.EvalLinTransKeyGen(secret_key, ncols, backend.LinTransType.TRANSPOSE)
+    rows, cols = ctm_matrix.shape
+    if rows == 1 or cols == 1:
+        return
+    backend.EvalTransposeKeyGen(secret_key, rows, cols)
+
+
+def gen_transform_keys(secret_key: openfhe.PrivateKey, tensor):
+    """Generate the keys needed to transform a matrix in either direction."""
+    if tensor.ndim < 2:
+        return
+
+    from ..tensor.block_ctarray import BlockCTArray
+
+    if isinstance(tensor, BlockCTArray):
+        tensor = tensor.data[0]
+    if tensor.order not in (
+        backend.ArrayEncodingType.ROW_MAJOR,
+        backend.ArrayEncodingType.COL_MAJOR,
+    ):
+        raise ValueError("Order transform supports only ROW_MAJOR and COL_MAJOR.")
+
+    gen_transpose_keys(secret_key, tensor)
 
 
 def generate_slicing_key(secret_key, original_shape):

--- a/openfhe_numpy/operations/matrix_arithmetic.py
+++ b/openfhe_numpy/operations/matrix_arithmetic.py
@@ -416,7 +416,7 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
 
     if axis is None:
         # Sum all elements in a packed-encoded matrix ciphertext: fhe_data
-        ct_sum = cc.EvalSum(fhe_data, nrows * ncols - 1)
+        ct_sum = cc.EvalSum(fhe_data, nrows * ncols)
         if keepdims:
             shape, padded_shape = (1, 1), x.shape
         else:
@@ -466,6 +466,9 @@ def _ct_sum_matrix(x: ArrayLike, axis: Optional[int] = None, keepdims: bool = Tr
             order = ArrayEncodingType.ROW_MAJOR
         elif order == ArrayEncodingType.COL_MAJOR:
             ct_sum = cc.EvalSumRows(fhe_data, nrows, x.extra["rowkey"], 0)
+            input_repeats = x.geometry.repeats if x.geometry is not None else 1
+            if input_repeats > 1:
+                ct_sum = cc.EvalMult(ct_sum, 1.0 / input_repeats)
             padded_shape = (ncols, nrows)
             order = ArrayEncodingType.COL_MAJOR
         else:

--- a/openfhe_numpy/tensor/block_ctarray.py
+++ b/openfhe_numpy/tensor/block_ctarray.py
@@ -106,6 +106,20 @@ class BlockCTArray(BlockFHETensor[Ciphertext]):
         """Return the blockwise homomorphic negation."""
         return self.clone(data=[-block for block in self.data])
 
+    def transform(self, order: int) -> BlockCTArray:
+        """Change the packing order of every matrix block."""
+        if order == self.order or self.ndim < 2:
+            return self
+
+        return type(self)(
+            data=[block.transform(order) for block in self.data],
+            grid_shape=self.grid_shape,
+            block_shape=self.block_shape,
+            original_shape=self.original_shape,
+            batch_size=self.batch_size,
+            order=order,
+        )
+
     def apply(self, func: Callable, *args: Any, **kwargs: Any) -> "BlockCTArray":
         """Apply a ciphertext-level function to every encrypted block.
 

--- a/openfhe_numpy/tensor/ctarray.py
+++ b/openfhe_numpy/tensor/ctarray.py
@@ -281,7 +281,13 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
     def _transpose(self) -> "CTArray":
         """Internal function to evaluate transpose of an encrypted array."""
         if self.ndim == 2:
-            ciphertext = EvalTranspose(self.data, self.ncols)
+            rows, cols = self.shape
+            if rows == 1 or cols == 1:
+                ciphertext = self.data
+            else:
+                if self.order == ArrayEncodingType.COL_MAJOR:
+                    rows, cols = cols, rows
+                ciphertext = EvalTranspose(self.data, rows, cols)
             pre_padded_shape = (
                 self.original_shape[1],
                 self.original_shape[0],
@@ -307,6 +313,32 @@ class CTArray(FHETensor[openfhe.Ciphertext]):
             padded_shape,
             self.order,
             geometry=geometry,
+        )
+
+    def transform(self, order: int) -> "CTArray":
+        """Convert COL_MAJOR to ROW_MAJOR and vice versal"""
+        if order not in (
+            ArrayEncodingType.ROW_MAJOR,
+            ArrayEncodingType.COL_MAJOR,
+        ):
+            raise ValueError("Order must be ROW_MAJOR or COL_MAJOR.")
+        if order == self.order or self.ndim < 2:
+            return self
+
+        from ..operations.arithmetic_utils import _eval_transform
+
+        ciphertext = _eval_transform(
+            self.data,
+            self.shape,
+            self.order,
+        )
+        return CTArray(
+            ciphertext,
+            self.original_shape,
+            self.batch_size,
+            self.shape,
+            order,
+            geometry=self.geometry,
         )
 
     def cumsum(self, axis=None) -> "CTArray":


### PR DESCRIPTION
## Summary

This PR adds order conversion (close #73 ), supports transpose for rectangular encrypted matrices, and fixes two issues in matrix `sum`.

## Changes

### Rectangular transpose

* Adds `EvalTranspose(ciphertext, numRows, numCols)`, key-generation overloads, and Python bindings.

### Order conversion

* Adds `CTArray.transform(order)` for row-major - column-major repacking.

### Matrix `sum` fixes

* For `axis=1` with column-major order, divides by the frame-repeat count, preventing inflated sums.

